### PR TITLE
refactor(create-router): decouple DOM specific methods into factory

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
       "import": {
         "./index.js": "{ createRouter }"
       },
-      "limit": "771 B"
+      "limit": "815 B"
     }
   ],
   "yaspeller": {


### PR DESCRIPTION
All DOM specific API isolated and could be moved into own module or package alongside with DOM specific tests

Bringing this for discussion purposes first of all.
I'd like to ask a permission to extract `bindRouterEvents` as separate repo/module.
I'm thinking about making a collection of small modules helpers that allow to build own routing solutions.

Unfortunately it brings extra 44 B, but it reduces responsibility of router module.
