### PR TITLE
Fix the way we detect numbers in keys

### DIFF
--- a/deep-map/index.test.ts
+++ b/deep-map/index.test.ts
@@ -368,3 +368,10 @@ test('passes previous value to subscribers', () => {
   deepStrictEqual(events, [undefined, { a: 0 }, { a: 1 }])
   unbind()
 })
+
+test('keys starting with numbers do not create unnecessary arrays', () => {
+  let $store = deepMap<{ key?: { '100key': string } }>({})
+
+  $store.setKey('key.100key', 'value')
+  deepStrictEqual($store.get(), { key: { '100key': 'value' } })
+})

--- a/deep-map/path.js
+++ b/deep-map/path.js
@@ -49,16 +49,17 @@ function getKeyAndIndicesFromKey(key) {
   return [key]
 }
 
+const IS_NUMBER = /^\d+$/
 function ensureKey(obj, key, nextKey) {
   if (key in obj) {
     return
   }
-  let nextKeyAsInt = parseInt(
-    nextKey !== null && nextKey !== undefined ? nextKey : ''
-  )
-  if (Number.isNaN(nextKeyAsInt)) {
-    obj[key] = {}
+
+  let isNum = IS_NUMBER.test(nextKey)
+
+  if (isNum) {
+    obj[key] = Array(parseInt(nextKey, 10) + 1).fill(undefined)
   } else {
-    obj[key] = Array(nextKeyAsInt + 1).fill(undefined)
+    obj[key] = {}
   }
 }

--- a/deep-map/path.test.ts
+++ b/deep-map/path.test.ts
@@ -113,3 +113,12 @@ test('array items mutation changes identity on the same level', () => {
   notEqual(newInitial.a.b.c.d[1], arr2)
   deepStrictEqual(newInitial.a.b.c.d[1], { a: 3 })
 })
+
+test('setting path with numbers inside does not produce any unnecessary stuff inside', () => {
+  let obj: any = {}
+
+  obj = setPath(obj, '123key', 'value')
+  obj = setPath(obj, 'key123', 'value')
+
+  deepStrictEqual(obj, { '123key': 'value', 'key123': 'value' })
+})


### PR DESCRIPTION
Fixes #284.

Extremely dumb bug.

As usual, unsafe use of `parseInt` backfired. Instead of relying on `parseInt` + `Number.isNaN` we now rely on a strict regex that makes sure the key is definitely digits only; in that case we set the key to be an array; otherwise it becomes an object as intended.

This still leaves a bit of space for possible superfluous edge cases (e.g., numerical keys in objects, or string keys in arrays), but I hope TS will warn people not to do that kind of things.