### PR TITLE
Add `batch` primitive for grouping writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,12 @@ batch(() => {
 // effects depending on either atom run once, with both new values visible
 ```
 
+Inside a `batch`, `Map#setKey` writes are coalesced too. The listener fires
+once and its `changed` argument is `undefined` (the batch touched multiple
+keys), so `listenKeys` subscribers fire once regardless of which key they
+watch. Outside a `batch`, each `setKey` still notifies with its own `changed`
+key as before.
+
 ### Map Creator
 
 If you have many similar stores (for instance, in advanced database ORM),

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ export const Admins = () => {
   - [Lazy Stores](#lazy-stores)
   - [Computed Stores](#computed-stores)
   - [Effects](#effects)
+  - [Batching](#batching)
   - [Map Creator](#map-creator)
   - [Tasks](#tasks)
   - [Store Events](#store-events)
@@ -389,6 +390,26 @@ const cancelPing = effect([$enabled, $interval], (enabled, interval) => {
     clearInterval(intervalId)
   }
 })
+```
+
+### Batching
+
+`batch` groups multiple store writes into a single transaction. Listeners and
+effects fire at most once when the outermost `batch` returns, observing the
+final values. Batches can be nested; only the outermost flush triggers the
+notifications.
+
+```js
+import { atom, batch } from 'nanostores'
+
+const $firstName = atom('')
+const $lastName = atom('')
+
+batch(() => {
+  $firstName.set('Ada')
+  $lastName.set('Lovelace')
+})
+// effects depending on either atom run once, with both new values visible
 ```
 
 ### Map Creator

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -172,3 +172,30 @@ export function atom<Value, StoreExt = object>(
 export function readonlyType<Value>(
   store: ReadableAtom<Value>
 ): ReadableAtom<Value>
+
+/**
+ * Run multiple store changes as a single transaction. While inside `batch`,
+ * listeners are deferred and each listener fires at most once when the
+ * outermost `batch` returns — with the final store values.
+ *
+ * Batches can be nested; only the outermost batch triggers the flush.
+ *
+ * Synchronous only. The batch closes when `fn` returns, so writes performed
+ * in microtasks, timers, or after `await` will not be batched. Pass a sync
+ * function.
+ *
+ * ```ts
+ * import { atom, batch } from 'nanostores'
+ *
+ * let $a = atom(0)
+ * let $b = atom(0)
+ *
+ * batch(() => {
+ *   $a.set(1)
+ *   $b.set(2)
+ * })
+ * ```
+ *
+ * @param fn Callback that performs the store writes.
+ */
+export function batch(fn: () => void): void

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -184,6 +184,9 @@ export function readonlyType<Value>(
  * in microtasks, timers, or after `await` will not be batched. Pass a sync
  * function.
  *
+ * `Map#setKey` writes are coalesced as well, so the listener's `changed`
+ * argument is `undefined` for the batched notification.
+ *
  * ```ts
  * import { atom, batch } from 'nanostores'
  *

--- a/atom/index.js
+++ b/atom/index.js
@@ -2,12 +2,45 @@ import { clean } from '../clean-stores/index.js'
 
 let listenerQueue = []
 let lqIndex = 0
+let batchSeen = null
 const QUEUE_ITEMS_PER_LISTENER = 4
 // Use globalThis.nanostoresGlobal to store epoch so all module instances share
 // the same counter. This fixes issues when Nano Store is bundled separately
 // in different parts of an application (e.g., tree-shaking separates core
 // from React), causing each bundle to have its own epoch instance.
 export const nanostoresGlobal = (globalThis.nanostoresGlobal ||= { epoch: 0 })
+
+let drainQueue = () => {
+  for (
+    lqIndex = 0;
+    lqIndex < listenerQueue.length;
+    lqIndex += QUEUE_ITEMS_PER_LISTENER
+  ) {
+    listenerQueue[lqIndex](
+      listenerQueue[lqIndex + 1].value,
+      listenerQueue[lqIndex + 2],
+      listenerQueue[lqIndex + 3]
+    )
+  }
+  listenerQueue.length = 0
+}
+
+/* @__NO_SIDE_EFFECTS__ */
+export const batch = fn => {
+  let outer = !batchSeen
+  if (outer) batchSeen = new Set()
+  try {
+    fn()
+  } finally {
+    if (outer) {
+      try {
+        if (listenerQueue.length) drainQueue()
+      } finally {
+        batchSeen = null
+      }
+    }
+  }
+}
 
 /* @__NO_SIDE_EFFECTS__ */
 export const atom = initialValue => {
@@ -45,24 +78,15 @@ export const atom = initialValue => {
     },
     notify(oldValue, changedKey) {
       nanostoresGlobal.epoch++
-      let runListenerQueue = !listenerQueue.length
+      let runListenerQueue = !listenerQueue.length && !batchSeen
       for (let listener of listeners) {
-        listenerQueue.push(listener, $atom.value, oldValue, changedKey)
+        if (!changedKey && batchSeen?.has(listener)) continue
+        if (!changedKey) batchSeen?.add(listener)
+        listenerQueue.push(listener, $atom, oldValue, changedKey)
       }
 
       if (runListenerQueue) {
-        for (
-          lqIndex = 0;
-          lqIndex < listenerQueue.length;
-          lqIndex += QUEUE_ITEMS_PER_LISTENER
-        ) {
-          listenerQueue[lqIndex](
-            listenerQueue[lqIndex + 1],
-            listenerQueue[lqIndex + 2],
-            listenerQueue[lqIndex + 3]
-          )
-        }
-        listenerQueue.length = 0
+        drainQueue()
       }
     },
     /* It will be called on last listener unsubscribing.

--- a/atom/index.js
+++ b/atom/index.js
@@ -80,9 +80,14 @@ export const atom = initialValue => {
       nanostoresGlobal.epoch++
       let runListenerQueue = !listenerQueue.length && !batchSeen
       for (let listener of listeners) {
-        if (!changedKey && batchSeen?.has(listener)) continue
-        if (!changedKey) batchSeen?.add(listener)
-        listenerQueue.push(listener, $atom, oldValue, changedKey)
+        if (batchSeen?.has(listener)) continue
+        batchSeen?.add(listener)
+        listenerQueue.push(
+          listener,
+          $atom,
+          oldValue,
+          batchSeen ? undefined : changedKey
+        )
       }
 
       if (runListenerQueue) {

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -646,7 +646,7 @@ test('notify dedupes the same listener across atoms in a batch', () => {
   unbindB()
 })
 
-test('listenKeys still receives each changed key inside a batch', () => {
+test('listenKeys fires once with undefined key inside a batch', () => {
   let $user = map({ age: 0, name: 'A' })
   let nameKey: unknown[] = []
   let ageKey: unknown[] = []
@@ -658,14 +658,14 @@ test('listenKeys still receives each changed key inside a batch', () => {
     $user.setKey('age', 1)
   })
 
-  deepStrictEqual(nameKey, ['name'])
-  deepStrictEqual(ageKey, ['age'])
+  deepStrictEqual(nameKey, [undefined])
+  deepStrictEqual(ageKey, [undefined])
 
   unbindName()
   unbindAge()
 })
 
-test('batch do not dedupe repeated setKey on the same key', () => {
+test('batch dedupes repeated setKey on the same key', () => {
   let $user = map({ age: 0, name: 'A' })
   let names: string[] = []
   let unbind = $user.listen(v => names.push(v.name))
@@ -680,7 +680,21 @@ test('batch do not dedupe repeated setKey on the same key', () => {
     $user.setKey('name', 'E')
   })
 
-  deepStrictEqual(names, ['E', 'E', 'E', 'E'])
+  deepStrictEqual(names, ['E'])
+  unbind()
+})
+
+test('batch coalesces setKey on different keys into one undefined-key call', () => {
+  let $user = map({ age: 0, name: 'A' })
+  let calls: [string, number, unknown][] = []
+  let unbind = $user.listen((v, _o, k) => calls.push([v.name, v.age, k]))
+
+  batch(() => {
+    $user.setKey('name', 'B')
+    $user.setKey('age', 1)
+  })
+
+  deepStrictEqual(calls, [['B', 1, undefined]])
   unbind()
 })
 

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -2,7 +2,16 @@ import FakeTimers from '@sinonjs/fake-timers'
 import { deepStrictEqual, equal } from 'node:assert'
 import { test } from 'node:test'
 
-import { atom, onMount, readonlyType } from '../index.js'
+import {
+  atom,
+  batch,
+  computed,
+  effect,
+  listenKeys,
+  map,
+  onMount,
+  readonlyType
+} from '../index.js'
 
 let clock = FakeTimers.install()
 
@@ -441,4 +450,250 @@ test('has readonly helper', () => {
   let $store = atom('1')
   let $readonly = readonlyType($store)
   equal($readonly, $store)
+})
+
+test('batch fires each listener once with the final values', () => {
+  let $a = atom(0)
+  let events: [number, number | undefined][] = []
+  let unbind = $a.listen((value, oldValue) => {
+    events.push([value, oldValue])
+  })
+
+  batch(() => {
+    $a.set(1)
+    $a.set(2)
+    $a.set(3)
+  })
+
+  equal(events.length, 1)
+  equal(events[0]?.[0], 3)
+  equal(events[0]?.[1], 0)
+  unbind()
+})
+
+test('batch defers cross-store listeners and dedupes them', () => {
+  let $a = atom(0)
+  let $b = atom(0)
+  let runs = 0
+  let last: [number, number] = [-1, -1]
+
+  effect([$a, $b], (a, b) => {
+    runs += 1
+    last = [a, b]
+  })
+  equal(runs, 1)
+
+  batch(() => {
+    $a.set(1)
+    $b.set(2)
+    $a.set(3)
+    $b.set(4)
+  })
+
+  equal(runs, 2)
+  deepStrictEqual(last, [3, 4])
+})
+
+test('batch on computed: derived values reflect post-batch state once', () => {
+  let $a = atom(0)
+  let $b = atom(0)
+  let $sum = computed([$a, $b], (a, b) => a + b)
+  let log: number[] = []
+  let unbind = $sum.listen(value => log.push(value))
+
+  batch(() => {
+    $a.set(10)
+    $b.set(5)
+  })
+
+  deepStrictEqual(log, [15])
+  unbind()
+})
+
+test('nested batch flushes only at the outermost exit', () => {
+  let $a = atom(0)
+  let log: number[] = []
+  let unbind = $a.listen(value => log.push(value))
+
+  batch(() => {
+    $a.set(1)
+    batch(() => {
+      $a.set(2)
+      $a.set(3)
+    })
+    equal(log.length, 0)
+    $a.set(4)
+  })
+
+  deepStrictEqual(log, [4])
+  unbind()
+})
+
+test('batch outside any listener is identical to a single set', () => {
+  let $a = atom(0)
+  let log: number[] = []
+  let unbind = $a.listen(value => log.push(value))
+
+  batch(() => {
+    $a.set(1)
+  })
+
+  deepStrictEqual(log, [1])
+
+  $a.set(2)
+  deepStrictEqual(log, [1, 2])
+  unbind()
+})
+
+test('batch coalesces sets driven through a generator', () => {
+  let $a = atom(0)
+  let events: [number, number | undefined][] = []
+  let unbind = $a.listen((value, oldValue) => {
+    events.push([value, oldValue])
+  })
+
+  function* gen(): Generator<void, void, unknown> {
+    $a.set(1)
+    yield
+    $a.set(2)
+    yield
+    $a.set(3)
+  }
+
+  batch(() => {
+    let it = gen()
+    let step = it.next()
+    while (!step.done) {
+      equal(events.length, 0)
+      step = it.next()
+    }
+  })
+
+  equal(events.length, 1)
+  equal(events[0]?.[0], 3)
+  equal(events[0]?.[1], 0)
+  unbind()
+})
+
+test('exception inside batch still flushes pending listeners', () => {
+  let $a = atom(0)
+  let log: number[] = []
+  let unbind = $a.listen(value => log.push(value))
+
+  let threw = false
+  try {
+    batch(() => {
+      $a.set(1)
+      throw new Error('boom')
+    })
+  } catch {
+    threw = true
+  }
+
+  equal(threw, true)
+  deepStrictEqual(log, [1])
+  unbind()
+})
+
+test('batch does not affect non-batched single-set behavior', () => {
+  let $a = atom(0)
+  let $b = atom(0)
+  let log: string[] = []
+  let unbindA = $a.listen(v => log.push(`a=${v}`))
+  let unbindB = $b.listen(v => log.push(`b=${v}`))
+
+  $a.set(1)
+  $b.set(2)
+  deepStrictEqual(log, ['a=1', 'b=2'])
+
+  unbindA()
+  unbindB()
+})
+
+test('notify defers drain while batchSeen is active', () => {
+  let $a = atom(0)
+  let calls: number[] = []
+  let unbind = $a.listen(value => calls.push(value))
+
+  batch(() => {
+    $a.set(1)
+    equal(calls.length, 0)
+    $a.notify(0)
+    equal(calls.length, 0)
+  })
+
+  equal(calls.length, 1)
+  unbind()
+})
+
+test('notify dedupes the same listener across atoms in a batch', () => {
+  let $a = atom(0)
+  let $b = atom(0)
+  let calls = 0
+  let listener = (): void => {
+    calls += 1
+  }
+  let unbindA = $a.listen(listener)
+  let unbindB = $b.listen(listener)
+
+  batch(() => {
+    $a.set(1)
+    $b.set(2)
+  })
+
+  equal(calls, 1)
+  unbindA()
+  unbindB()
+})
+
+test('listenKeys still receives each changed key inside a batch', () => {
+  let $user = map({ age: 0, name: 'A' })
+  let nameKey: unknown[] = []
+  let ageKey: unknown[] = []
+  let unbindName = listenKeys($user, ['name'], (_v, _o, k) => nameKey.push(k))
+  let unbindAge = listenKeys($user, ['age'], (_v, _o, k) => ageKey.push(k))
+
+  batch(() => {
+    $user.setKey('name', 'B')
+    $user.setKey('age', 1)
+  })
+
+  deepStrictEqual(nameKey, ['name'])
+  deepStrictEqual(ageKey, ['age'])
+
+  unbindName()
+  unbindAge()
+})
+
+test('batch do not dedupe repeated setKey on the same key', () => {
+  let $user = map({ age: 0, name: 'A' })
+  let names: string[] = []
+  let unbind = $user.listen(v => names.push(v.name))
+
+  batch(() => {
+    $user.setKey('name', 'B')
+    batch(() => {
+      $user.setKey('name', 'C')
+      $user.setKey('name', 'D')
+    })
+    equal(names.length, 0)
+    $user.setKey('name', 'E')
+  })
+
+  deepStrictEqual(names, ['E', 'E', 'E', 'E'])
+  unbind()
+})
+
+test('batch dedupes whole-store map.set notifications', () => {
+  let $user = map({ age: 0, name: 'A' })
+  let calls: string[] = []
+  let unbind = $user.listen((_v, _o, k) => calls.push(k))
+
+  batch(() => {
+    $user.set({ name: 'B', age: 1 })
+    $user.set({ name: 'C', age: 2 })
+  })
+
+  deepStrictEqual(calls, [undefined])
+  unbind()
 })

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -5,6 +5,7 @@ import { test } from 'node:test'
 import {
   allTasks,
   atom,
+  batch,
   batched,
   computed,
   map,
@@ -191,6 +192,48 @@ test('prevents diamond dependency problem 4 (complex)', () => {
 
   unsubscribe1()
   unsubscribe2()
+})
+
+test('batched diamond fires downstream once with final values', () => {
+  let $store1 = atom(0)
+  let $store2 = atom(0)
+  let log: string[] = []
+
+  let $a = computed($store1, v => `a${v}`)
+  let $b = computed($store2, v => `b${v}`)
+  let $combined = computed([$a, $b], (a, b) => `${a}${b}`)
+
+  let unsubscribe = $combined.subscribe(v => log.push(v))
+  deepStrictEqual(log, ['a0b0'])
+
+  batch(() => {
+    $store1.set(1)
+    $store2.set(2)
+  })
+  deepStrictEqual(log, ['a0b0', 'a1b2'])
+
+  unsubscribe()
+})
+
+test('batched updates do not observe transient values across siblings', () => {
+  let $base = atom(0)
+  let log: string[] = []
+
+  let $left = computed($base, v => v * 10)
+  let $right = computed($base, v => v * 100)
+  let $sum = computed([$left, $right], (l, r) => l + r)
+
+  let unsubscribe = $sum.subscribe(v => log.push(`sum=${v}`))
+  deepStrictEqual(log, ['sum=0'])
+
+  batch(() => {
+    $base.set(1)
+    $base.set(2)
+    $base.set(3)
+  })
+  deepStrictEqual(log, ['sum=0', 'sum=330'])
+
+  unsubscribe()
 })
 
 test('prevents diamond dependency problem 5', () => {

--- a/deep-map/index.d.ts
+++ b/deep-map/index.d.ts
@@ -25,7 +25,8 @@ export type DeepMapStore<T extends BaseDeepMap> = {
    *
    * @param listener Callback with store value and old value.
    * @param changedKey Key that was changed. Will present only if `setKey`
-   *                   has been used to change a store.
+   *                   has been used to change a store. It is `undefined` when
+   *                   changes were coalesced inside `batch`.
    * @returns Function to remove listener.
    */
   listen(
@@ -75,7 +76,8 @@ export type DeepMapStore<T extends BaseDeepMap> = {
    *
    * @param listener Callback with store value and old value.
    * @param changedKey Key that was changed. Will present only
-   *                   if `setKey` has been used to change a store.
+   *                   if `setKey` has been used to change a store. It is
+   *                   `undefined` when changes were coalesced inside `batch`.
    * @returns Function to remove listener.
    */
   subscribe(

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 export {
   atom,
   Atom,
+  batch,
   PreinitializedWritableAtom,
   ReadableAtom,
   readonlyType,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-export { atom, readonlyType } from './atom/index.js'
+export { atom, batch, readonlyType } from './atom/index.js'
 export { clean, cleanStores } from './clean-stores/index.js'
 export { batched, computed } from './computed/index.js'
 export {

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -54,7 +54,8 @@ export interface MapStore<
    *
    * @param listener Callback with store value and old value.
    * @param changedKey Key that was changed. Will present only if `setKey`
-   *                   has been used to change a store.
+   *                   has been used to change a store. It is `undefined` when
+   *                   changes were coalesced inside `batch`.
    * @returns Function to remove listener.
    */
   listen(
@@ -121,7 +122,8 @@ export interface MapStore<
    *
    * @param listener Callback with store value and old value.
    * @param changedKey Key that was changed. Will present only
-   *                   if `setKey` has been used to change a store.
+   *                   if `setKey` has been used to change a store. It is
+   *                   `undefined` when changes were coalesced inside `batch`.
    * @returns Function to remove listener.
    */
   subscribe(

--- a/package.json
+++ b/package.json
@@ -61,14 +61,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "335 B"
+      "limit": "340 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed }"
       },
-      "limit": "862 B"
+      "limit": "864 B"
     }
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -61,14 +61,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "294 B"
+      "limit": "335 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed }"
       },
-      "limit": "831 B"
+      "limit": "862 B"
     }
   ],
   "engines": {


### PR DESCRIPTION
## Overview
 
Adds `batch(fn)` — a synchronous primitive that groups multiple store writes so each listener fires at most once when the outermost batch exits, observing the final state.
 
## Problem Statement
 
Nanostores has no way to group multiple synchronous writes. When several stores (or the same store) are updated in sequence, every listener and downstream computed runs after each individual `set()`. This produces redundant work, intermediate values being observed by effects, and forces consumers to choose between awkward "update one big object" patterns or wearing the cost of N cascades for N writes.
 
Without a batching primitive, library authors also can't safely batch internally — wrapping a helper's writes in any deferred-flush mechanism prevents callers from composing their own batches around it.
 
## Solution Approach
 
- Adds `batch(fn)` exported from the root. While inside a batch, `atom.notify` defers the listener-queue drain. On the outermost exit, the queue drains with per-listener deduplication so each listener fires once with the final atom value.
- Listener tuples now carry the atom reference rather than a snapshot of its value at push time, so the deduped firing reads the current value via `$atom.value` at drain time. `oldValue` is preserved from the first push, giving the natural "pre-batch → post-batch" transition.
- Inside a batch, dedup applies to every listener: each fires once with `changedKey === undefined`, so repeated or multi-key `map.setKey` writes coalesce like a plain `set`. This reuses the existing `map.set(newObject)` case, where `changedKey` is already undefined, so `listenKeys` subscribers behave exactly as they do for a full `map.set`. Behavior outside a batch is unchanged. Passing an array of changed keys as the third listener argument is left for the next major.
- Nesting is supported and exception-safe: inner batches are no-ops for flush purposes; the outermost `try/finally` always drains and clears the dedup set, including when `fn` throws. Note this also means `batch` is not a transaction: writes are not rolled back if `fn` throws, only their notifications are grouped.
- README gains a "Batching" section and TOC entry. `atom/index.d.ts` declares the new export, and root `index.{js,d.ts}` re-export it.
## Breaking Changes
 
None. Behavior outside a `batch(...)` call is unchanged — every existing test passes, including the diamond suite.
 
## Testing
 
- New tests in `atom/index.test.ts` cover the core semantics — coalescing, nesting, exception safety, computed and effect under batch, `map.setKey` + `listenKeys` correctness — and `computed/index.test.ts` adds batched-diamond cases.
## Size change
 
+46 B for Atom / +33 B for Popular set.