### PR TITLE
Reset computed cache on cleanStores

### DIFF
--- a/clean-stores/index.test.ts
+++ b/clean-stores/index.test.ts
@@ -5,6 +5,7 @@ import {
   atom,
   clean,
   cleanStores,
+  computed,
   map,
   type MapCreator,
   type MapStore,
@@ -149,6 +150,29 @@ test('allows to call multiple times', () => {
   cleanStores(loaded, Model)
 
   deepStrictEqual(events, ['loaded', 'built 1', 'built 2'])
+})
+
+test('resets computed cache', () => {
+  let multiplier = 2
+  let computations = 0
+  let $source = atom(1)
+  let $computed = computed($source, value => {
+    computations += 1
+    return value * multiplier
+  })
+
+  let unbind = $computed.subscribe(() => {})
+  equal($computed.get(), 2)
+  equal(computations, 1)
+  unbind()
+
+  cleanStores($source, $computed)
+
+  multiplier = 10
+  let unbind2 = $computed.subscribe(() => {})
+  equal($computed.get(), 10)
+  equal(computations, 2)
+  unbind2()
 })
 
 test('throws in production', () => {

--- a/computed/index.js
+++ b/computed/index.js
@@ -1,4 +1,5 @@
 import { atom, nanostoresGlobal } from '../atom/index.js'
+import { clean } from '../clean-stores/index.js'
 import { onMount } from '../lifecycle/index.js'
 import { warn } from '../warn/index.js'
 
@@ -37,6 +38,16 @@ let computedStore = (stores, cb, batched) => {
   $computed.get = () => {
     set()
     return get()
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    let cleanComputed = $computed[clean]
+    $computed[clean] = () => {
+      previousArgs = undefined
+      currentEpoch = undefined
+      $computed.value = undefined
+      cleanComputed()
+    }
   }
 
   let timer


### PR DESCRIPTION
## Problem
`cleanStores()` resets stores via their internal `[clean]` method, but `computed()` (and `batched()`) stores never defined one. They cache `previousArgs`, `currentEpoch`, and the inner atom's `value` in a closure, so `cleanStores()` only reset the underlying atom's listeners — the computed value stayed stale between tests.

## Fix
Define `$computed[clean]` (dev/test only, mirroring `atom`'s `[clean]`) to clear `previousArgs`, `currentEpoch`, and the cached `value`, then delegate to the atom's existing clean handler. The value is now recomputed after `cleanStores()`. The dev-only code is tree-shaken from production builds (size-limit unaffected). Added a regression test.

Closes #323