### PR TITLE
Fix getPath throwing on null intermediate values

### DIFF
--- a/deep-map/index.test.ts
+++ b/deep-map/index.test.ts
@@ -448,3 +448,17 @@ test('getKey returns correct value for array indices', () => {
   equal(getKey($store, 'nested[2]'), undefined)
   equal(getKey($store, 'nested[2].id'), undefined)
 })
+
+test('getKey returns undefined for keys under a null value', () => {
+  let $store = deepMap<{ a: null | { b: number } }>({ a: null })
+
+  equal(getKey($store, 'a'), null)
+  equal(getKey($store, 'a.b'), undefined)
+})
+
+test('setKey can set a deep key when an intermediate value is null', () => {
+  let $store = deepMap<{ a: null | { b: number } }>({ a: null })
+
+  $store.setKey('a.b', 1)
+  deepStrictEqual($store.get(), { a: { b: 1 } })
+})

--- a/deep-map/path.js
+++ b/deep-map/path.js
@@ -2,8 +2,8 @@ export function getPath(obj, path) {
   let allKeys = getAllKeysFromPath(path)
   let res = obj
   for (let key of allKeys) {
-    if (res === undefined) {
-      break
+    if (res == null) {
+      return undefined
     }
     res = res[key]
   }

--- a/deep-map/path.test.ts
+++ b/deep-map/path.test.ts
@@ -24,6 +24,21 @@ test('path evaluates correct value', () => {
   equal(getPath(exampleObj, 'abra.cadabra.booms'), undefined)
 })
 
+test('path returns undefined for keys under null or undefined values', () => {
+  let exampleObj = {
+    a: null,
+    b: undefined,
+    c: { d: null }
+  }
+
+  // @ts-expect-error: incorrect key here
+  equal(getPath(exampleObj, 'a.b'), undefined)
+  // @ts-expect-error: incorrect key here
+  equal(getPath(exampleObj, 'b.c'), undefined)
+  // @ts-expect-error: incorrect key here
+  equal(getPath(exampleObj, 'c.d.e'), undefined)
+})
+
 test('simple path setting', () => {
   type TestObj = {
     a: {


### PR DESCRIPTION
## Problem

`getPath()` (and therefore the public `getKey()` and `deepMap().setKey()`) throws a `TypeError` when a path traverses through a `null` value, instead of returning `undefined` like it already does for missing/`undefined` intermediates.

```js
import { deepMap, getKey } from 'nanostores'

let $store = deepMap({ a: null })

getKey($store, 'a.b')      // TypeError: Cannot read properties of null (reading 'b')
$store.setKey('a.b', 1)    // TypeError: Cannot read properties of null (reading 'b')
```

`setKey` throws because it calls `getPath()` for its change-detection check before writing. `setPath()` itself already handles `null` correctly, so once `getPath()` stops throwing, `setKey('a.b', 1)` on `{ a: null }` produces `{ a: { b: 1 } }` as expected.

`null` is a very common value in real data (JSON payloads, optional/cleared fields), so reading or setting a deeper key under it should not crash.

## Fix

The traversal guard in `getPath()` only checked for `undefined`. Loosening it to `== null` makes it stop at both `null` and `undefined`, returning `undefined` for the unreachable path — consistent with the existing behavior for missing keys.

```diff
   for (let key of allKeys) {
-    if (res === undefined) {
-      break
+    if (res == null) {
+      return undefined
     }
     res = res[key]
   }
```

Reading a `null` value *directly* (e.g. `getKey($store, 'a')`) still returns `null` — only traversing *through* it returns `undefined`.

## Tests

- `deep-map/path.test.ts`: `getPath` returns `undefined` for keys under `null`/`undefined` values.
- `deep-map/index.test.ts`: `getKey` returns `undefined` through a `null` value, and `setKey` can set a deep key when an intermediate value is `null`.

All existing tests pass; the new tests fail without the one-line fix.