### PR TITLE
Add initial debounce function (WIP)

### DIFF
--- a/debounce/index.d.ts
+++ b/debounce/index.d.ts
@@ -1,0 +1,6 @@
+import type { ReadableAtom, WritableAtom } from '../atom/index.js'
+
+export function timeoutDebounce<T>(
+  inAtom: WritableAtom<T>,
+  timeout = 0
+): ReadableAtom<T>

--- a/debounce/index.js
+++ b/debounce/index.js
@@ -1,0 +1,27 @@
+let debounce = (inAtom, scheduleFn) => {
+  let outAtom = atom(inAtom.get())
+
+  let previousVal
+
+  inAtom.listen(val => {
+    if (!previousVal) {
+      scheduleFn(() => {
+        outAtom.set(previousVal)
+        previousVal = null
+      })
+    } else {
+      previousVal = val
+    }
+  })
+
+  return outAtom
+}
+
+export const timeoutDebounce = (inAtom, timeout) => {
+  timeout = timeout ?? 0
+  let scheduleFn = callback => {
+    setTimeout(val => callback(val), timeout)
+  }
+
+  return debounce(inAtom, scheduleFn)
+}

--- a/debounce/index.test.ts
+++ b/debounce/index.test.ts
@@ -1,0 +1,19 @@
+import FakeTimers from '@sinonjs/fake-timers'
+import { equal } from 'node:assert'
+import { test } from 'node:test'
+
+import { timeoutDebounce } from './index.js'
+import { atom } from '../atom/index.js'
+
+let clock = FakeTimers.install()
+
+test('debounces on call', () => {
+  let inAtom = atom(1)
+  let debouncedAtom = timeoutDebounce(inAtom, 0)
+
+  inAtom.set(2)
+  inAtom.set(3)
+
+  clock.runAll()
+  equal(debouncedAtom.get(), 3)
+})


### PR DESCRIPTION
This creates a generic debouncer that allows for things like:

```typescript
const inputAtom = atom(1);
const debouncedAtom = timeoutDebounce(inputAtom);

debouncedAtom.listen(console.log)

inputAtom.set(2)
inputAtom.set(3)

// After timeout expires, 3 will be logged
```