### PR TITLE
fix(listen-keys): no false-positive on whole-store set when watched keys are unchanged

### DIFF
--- a/listen-keys/index.js
+++ b/listen-keys/index.js
@@ -1,7 +1,11 @@
 export function listenKeys($store, keys, listener) {
-  let keysSet = new Set(keys).add(undefined)
+  let keysSet = new Set(keys)
   return $store.listen((value, oldValue, changed) => {
-    if (keysSet.has(changed)) {
+    if (
+      changed === undefined
+        ? keys.some(key => value[key] !== oldValue[key])
+        : keysSet.has(changed)
+    ) {
       listener(value, oldValue, changed)
     }
   })

--- a/listen-keys/index.test.ts
+++ b/listen-keys/index.test.ts
@@ -30,6 +30,56 @@ test('listen for specific keys', () => {
   deepStrictEqual(events, ['2 2', '3 2'])
 })
 
+test('does not fire when whole-store set leaves watched keys unchanged', () => {
+  let events: string[] = []
+  let $store = map({ a: 1, b: 2, c: 3 })
+
+  listenKeys($store, ['a', 'b'], (value, _, changed) => {
+    events.push(String(changed))
+  })
+  deepStrictEqual(events, [])
+
+  // Replace entire store but only change 'c' — watched keys 'a' and 'b' are untouched
+  $store.set({ a: 1, b: 2, c: 99 })
+  deepStrictEqual(events, [], 'should not fire when watched keys did not change')
+
+  // Replace store and change 'b' — should fire
+  $store.set({ a: 1, b: 99, c: 99 })
+  deepStrictEqual(events, ['undefined'])
+
+  // Replace store and change 'a' — should fire
+  $store.set({ a: 99, b: 99, c: 99 })
+  deepStrictEqual(events, ['undefined', 'undefined'])
+})
+
+test('fires for whole-store set when a watched key is newly added', () => {
+  let events: string[] = []
+  let $store = map<{ a?: number; b: number }>({ b: 1 })
+
+  listenKeys($store, ['a'], (value, _, changed) => {
+    events.push(String(changed))
+  })
+  deepStrictEqual(events, [])
+
+  // Whole-store set introduces key 'a' for the first time
+  $store.set({ a: 1, b: 1 })
+  deepStrictEqual(events, ['undefined'])
+})
+
+test('fires for whole-store set when a watched key is removed', () => {
+  let events: string[] = []
+  let $store = map<{ a?: number; b: number }>({ a: 1, b: 1 })
+
+  listenKeys($store, ['a'], (value, _, changed) => {
+    events.push(String(changed))
+  })
+  deepStrictEqual(events, [])
+
+  // Whole-store set removes key 'a'
+  $store.set({ b: 1 })
+  deepStrictEqual(events, ['undefined'])
+})
+
 test('can subscribe to changes and call listener immediately', () => {
   let events: string[] = []
   let $store = map({ a: 1, b: 1 })


### PR DESCRIPTION
## Bug

`listenKeys(store, ['a'], listener)` fires a false-positive notification
when `store.set(newObj)` is called but the value of key `'a'` did not
actually change.

### Root cause

`listenKeys` builds `new Set(keys).add(undefined)`. The `undefined`
entry was intended to catch whole-store replacements (`map.set()`),
where the atom's `notify()` passes `changedKey = undefined`. Because
`undefined` is unconditionally in the set, **every** whole-store
replacement triggers the listener regardless of whether any watched key
changed.

```js
// Before (buggy)
let keysSet = new Set(keys).add(undefined)
return $store.listen((value, oldValue, changed) => {
  if (keysSet.has(changed)) {   // always true when changed===undefined
    listener(value, oldValue, changed)
  }
})
```

### Repro

```js
import { listenKeys, map } from 'nanostores'

let $store = map({ a: 1, b: 2, c: 3 })
let calls = 0
listenKeys($store, ['a'], () => calls++)

$store.set({ a: 1, b: 2, c: 99 })  // only 'c' changed
console.log(calls)  // prints 1 — should be 0
```

## Fix

Remove the blanket `.add(undefined)`. When `changed === undefined`
(whole-store replacement via `map.set()`), iterate over the watched
keys and fire only if at least one value actually differs between
`oldValue` and `value`.

```js
// After (fixed)
let keysSet = new Set(keys)
return $store.listen((value, oldValue, changed) => {
  if (
    changed === undefined
      ? keys.some(key => value[key] !== oldValue[key])
      : keysSet.has(changed)
  ) {
    listener(value, oldValue, changed)
  }
})
```

Correct cases that still fire:
- whole-store set where a watched key changes value
- whole-store set that **adds** a watched key (was absent, now present)
- whole-store set that **removes** a watched key (was present, now absent)

## Tests added

Three new tests in `listen-keys/index.test.ts`:

| Test | Asserts |
|---|---|
| `does not fire when whole-store set leaves watched keys unchanged` | no false positive when unwatched key changes via `set()` |
| `fires for whole-store set when a watched key is newly added` | triggers when key goes from absent → present |
| `fires for whole-store set when a watched key is removed` | triggers when key goes from present → absent |

Full test suite (49 tests), lint, types, and 100% branch coverage all pass.