### PR TITLE
Support nested mutations (deepMap) is listenKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,15 @@ listenKeys($profile, ['name'], (value, oldValue, changed) => {
 })
 ```
 
+Nested mutations can be listened to using a base key. For example, listening to `user` will trigger on `user.name` mutations:
+
+```ts
+// Mutating user.name triggers the listener
+listenKeys($state, ['user'], (value, oldValue, changed) => {
+  console.log(`user changed: ${changed}`)
+})
+```
+
 `subscribeKeys(store, keys, cb)` in contrast with `listenKeys(store, keys, cb)`
 also call listeners immediately during the subscription.
 Please note that when using subscribe for store changes, the initial evaluation
@@ -478,6 +487,13 @@ export const Header = ({ postId }) => {
   const profile = useStore($profile)
   return <header>Hi, {profile.name}</header>
 }
+```
+
+Listening to a base key will automatically trigger a re-render if any of its nested properties mutate. avoinding having to pass a large array of deep keys.
+
+```tsx
+// Will listen for all changes in profile object
+const profile = useStore($profile, { keys: ["profile"] })
 ```
 
 [`@nanostores/preact`]: https://github.com/nanostores/preact

--- a/listen-keys/index.js
+++ b/listen-keys/index.js
@@ -4,7 +4,7 @@ export function listenKeys($store, keys, listener) {
     if (
       changed === undefined
         ? keys.some(key => value[key] !== oldValue[key])
-        : keysSet.has(changed)
+        : (keysSet.has(changed) || keysSet.has(changed.split(/\.|\[/)[0]))
     ) {
       listener(value, oldValue, changed)
     }


### PR DESCRIPTION
Following the discussion and implementation in [nanostores/react#44](https://github.com/nanostores/react/pull/44).
The listener now evaluates both the exact mutated path and its extracted **base key**:
1. Evaluates `keysSet.has(changed)` for exact matches.
2. Evaluates `keysSet.has(changed.split(/\.|\[/)[0])` to extract the base key of the mutation (e.g., `a.b` extracts to `a`, and `a[0]` extracts to `a`).

I also keep previous PR [#404](https://github.com/nanostores/nanostores/pull/406)

```js
//PR
if (changed === undefined
     ? keys.some(key => value[key] !== oldValue[key])
     - : (keysSet.has(changed)
     + : (keysSet.has(changed) || keysSet.has(changed.split(/\.|\[/)[0]))
) {
     listener(value, oldValue, changed)
}
```