### PR TITLE
fix: correct JSDoc typos in deep-map/path.d.ts

### DIFF
--- a/deep-map/path.d.ts
+++ b/deep-map/path.d.ts
@@ -109,7 +109,7 @@ export type BaseDeepMap = Record<string, unknown>
  * ```
  *
  * @param obj Any object.
- * @param path Path splitted by dots and `[]`. Like: `props.arr[1].nested`.
+ * @param path Path split by dots and `[]`. Like: `props.arr[1].nested`.
  * @returns The value for this path. Undefined if key is missing.
  */
 export function getPath<T extends BaseDeepMap, K extends AllPaths<T>>(
@@ -131,7 +131,7 @@ export function getPath<T extends BaseDeepMap, K extends AllPaths<T>>(
  * ```
  *
  * @param obj Any object.
- * @param path Path splitted by dots and `[]`. Like: `props.arr[1].nested`.
+ * @param path Path split by dots and `[]`. Like: `props.arr[1].nested`.
  * @returns The new object.
  */
 export function setPath<T extends BaseDeepMap, K extends AllPaths<T>>(
@@ -156,7 +156,7 @@ export function setPath<T extends BaseDeepMap, K extends AllPaths<T>>(
  * @param obj Any object.
  * @param splittedKeys An array of keys representing the path to the value.
  * @param value New value.
- * @retunts The new object.
+ * @returns The new object.
  */
 export function setByKey<T extends BaseDeepMap>(
   obj: T,


### PR DESCRIPTION
## Summary

Three typos in JSDoc comments inside `deep-map/path.d.ts`:

- `splitted` → `split` in `@param path` description for `getPath` (line 112)
- `splitted` → `split` in `@param path` description for `setPath` (line 134)
- `@retunts` → `@returns` in `setByKey` JSDoc tag (line 159)

"Splitted" is a non-standard form — the correct past participle of "split" is "split". The `@retunts` tag is a plain typo that would cause tools relying on JSDoc tags (typedoc, IDE hover docs) to silently ignore the return type description.

No logic changes — comments/documentation only.