### PR TITLE
Fix synchronous task callbacks

### DIFF
--- a/task/index.js
+++ b/task/index.js
@@ -15,7 +15,13 @@ export function startTask() {
 
 export function task(cb) {
   let endTask = startTask()
-  let promise = cb().finally(endTask)
+  let promise
+  try {
+    promise = Promise.resolve(cb()).finally(endTask)
+  } catch (error) {
+    endTask()
+    throw error
+  }
   promise.t = true
   return promise
 }

--- a/task/index.test.ts
+++ b/task/index.test.ts
@@ -1,7 +1,7 @@
-import { equal } from 'node:assert'
+import { equal, throws } from 'node:assert'
 import { test } from 'node:test'
 
-import { allTasks, startTask, task } from '../index.js'
+import { allTasks, cleanTasks, startTask, task } from '../index.js'
 
 test('waits no tasks', async () => {
   await allTasks()
@@ -45,4 +45,32 @@ test('ends task on error', async () => {
   }
   equal(catched, error)
   await allTasks()
+})
+
+test('returns synchronous task value', async () => {
+  try {
+    equal(await task(() => 5), 5)
+  } finally {
+    cleanTasks()
+  }
+})
+
+test('ends task on synchronous error', async () => {
+  let error = Error('test')
+  try {
+    throws(() => {
+      task(() => {
+        throw error
+      })
+    }, error)
+
+    let ended = false
+    allTasks().then(() => {
+      ended = true
+    })
+    await Promise.resolve()
+    equal(ended, true)
+  } finally {
+    cleanTasks()
+  }
 })


### PR DESCRIPTION
## Summary

Allow `task()` callbacks to return the synchronous values already accepted by its public type, and release task tracking if a callback throws synchronously.

## Problem

`task()` calls `.finally()` directly on the callback result. A synchronous value therefore throws `TypeError: cb(...).finally is not a function`. Because tracking starts before the callback runs, a synchronous exception also leaves the global task count active and causes later `allTasks()` calls to wait indefinitely.

## Changes

- Normalize successful callback results with `Promise.resolve()`.
- Release tracking before rethrowing synchronous callback errors.
- Add regression tests for synchronous results and synchronous errors.

## Testing

- `pnpm bnt task/index.test.ts`
- `pnpm exec bnt --coverage 100 --coverage-exclude "**/*.test.ts"`
- `pnpm test:lint`
- `pnpm test:types`
- `pnpm test:size`

## Before

Synchronous results throw a `TypeError`; synchronous errors leave `allTasks()` pending.

## After

Synchronous results resolve through the returned task promise, and every synchronous exit balances task tracking while preserving the original thrown error.

## Compatibility

No public type or signature changes. Callback invocation remains synchronous, and existing promise behavior is unchanged.

## Related issue

None; independently reproduced on the current default branch.
