### PR TITLE
Fix `batch()` being tree-shaken away by Rollup

### DIFF
--- a/atom/index.js
+++ b/atom/index.js
@@ -25,7 +25,6 @@ let drainQueue = () => {
   listenerQueue.length = 0
 }
 
-/* @__NO_SIDE_EFFECTS__ */
 export const batch = fn => {
   let outer = !batchSeen
   if (outer) batchSeen = new Set()


### PR DESCRIPTION
## Overview

Removes the `@__NO_SIDE_EFFECTS__` annotation from `batch()`, which allowed
Rollup-based bundlers to delete `batch()` calls, and the state updates inside
them, from production builds.

## Problem Statement

Reported in [#413](https://github.com/nanostores/nanostores/issues/413): code
using `batch()` works in development but silently loses its updates once built
for production. A call like

```js
batch(() => {
  $first.set(x)
  $second.set(y)
})
```

compiles down to nothing, so neither store is ever updated.

`@__NO_SIDE_EFFECTS__` declares that *any* call to a function has no side
effects, which lets a bundler drop the call whenever its result is unused.
That claim is false for `batch()`: it invokes the caller's callback, and it
returns `void`, so its result is unused at every call site. Every `batch()`
call in an application therefore qualifies for elimination.

The damage extends past the callback. Once the only writer of the internal
`batchSeen` flag is removed, it is constant-folded to `null` and the batching
branches inside `notify()` are stripped too, so the mechanism disappears from
the bundle entirely.

Confirmed on Rollup 4, Rolldown 1, and Vite builds, with and without
minification. esbuild does not act on the annotation and is unaffected, which
is why the problem was not visible in existing bundle-size checks. The
annotation is present in the published `nanostores@1.4.1`, so all consumers on
Rollup-based toolchains are exposed.

## Solution Approach

Dropped the annotation from `batch()` in `atom/index.js`.

## Breaking Changes

None. This restores intended behavior; no API, type, or signature changes.

Bundle size is unchanged. The annotation was providing no benefit: `batch()` is
still eliminated completely when an application never imports it, through
ordinary unused-export elimination combined with `"sideEffects": false`. The
annotation only ever governed removal of *calls*.