### PR TITLE
Keep listeners running when one of them throws

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tiny state manager for **React**, **React Native**, **Preact**, **Vue**,
 **Svelte**, **Solid**, **Lit**, **Angular**, and vanilla JS.
 It uses **many atomic stores** and direct manipulation.
 
-- **Small.** Between 340 and 864 bytes (minified and brotlied).
+- **Small.** Between 368 and 891 bytes (minified and brotlied).
   Zero dependencies. It uses [Size Limit] to control size.
 - **Fast.** With small atomic and derived stores, you do not need to call
   the selector function for all components on every store change.

--- a/atom/index.js
+++ b/atom/index.js
@@ -10,19 +10,28 @@ const QUEUE_ITEMS_PER_LISTENER = 4
 // from React), causing each bundle to have its own epoch instance.
 export const nanostoresGlobal = (globalThis.nanostoresGlobal ||= { epoch: 0 })
 
+// One listener throwing must not stop the others, and must not leave the queue
+// dirty: a non-empty queue makes every later notify think a drain is running.
 let drainQueue = () => {
+  // Holds the first thrown value, wrapped so that a falsy one is still rethrown
+  let thrown
   for (
     lqIndex = 0;
     lqIndex < listenerQueue.length;
     lqIndex += QUEUE_ITEMS_PER_LISTENER
   ) {
-    listenerQueue[lqIndex](
-      listenerQueue[lqIndex + 1].value,
-      listenerQueue[lqIndex + 2],
-      listenerQueue[lqIndex + 3]
-    )
+    try {
+      listenerQueue[lqIndex](
+        listenerQueue[lqIndex + 1].value,
+        listenerQueue[lqIndex + 2],
+        listenerQueue[lqIndex + 3]
+      )
+    } catch (e) {
+      thrown ||= [e]
+    }
   }
   listenerQueue.length = 0
+  if (thrown) throw thrown[0]
 }
 
 export const batch = fn => {

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -711,3 +711,134 @@ test('batch dedupes whole-store map.set notifications', () => {
   deepStrictEqual(calls, [undefined])
   unbind()
 })
+
+test('keeps other stores working after a listener throws', () => {
+  let $a = atom(0)
+  let $b = atom(0)
+  let log: number[] = []
+
+  $a.listen(() => {
+    throw new Error('boom')
+  })
+  $b.listen(value => log.push(value))
+
+  try {
+    $a.set(1)
+  } catch {}
+
+  $b.set(2)
+  deepStrictEqual(log, [2])
+})
+
+test('runs listeners queued after a throwing one', () => {
+  let $a = atom(0)
+  let log: string[] = []
+
+  $a.listen(() => log.push('first'))
+  $a.listen(() => {
+    throw new Error('boom')
+  })
+  $a.listen(() => log.push('third'))
+
+  try {
+    $a.set(1)
+  } catch {}
+
+  deepStrictEqual(log, ['first', 'third'])
+})
+
+test('rethrows the first error when several listeners throw', () => {
+  let $a = atom(0)
+  let log: string[] = []
+
+  $a.listen(() => {
+    throw new Error('first')
+  })
+  $a.listen(() => log.push('between'))
+  $a.listen(() => {
+    throw new Error('second')
+  })
+
+  let caught: unknown
+  try {
+    $a.set(1)
+  } catch (e) {
+    caught = e
+  }
+
+  equal((caught as Error).message, 'first')
+  deepStrictEqual(log, ['between'])
+})
+
+test('rethrows a falsy value thrown by a listener', () => {
+  let $a = atom(0)
+  let log: string[] = []
+  let falsy: unknown = 0
+
+  $a.listen(() => {
+    throw falsy
+  })
+  $a.listen(() => log.push('after'))
+
+  let threw = false
+  try {
+    $a.set(1)
+  } catch {
+    threw = true
+  }
+
+  equal(threw, true)
+  deepStrictEqual(log, ['after'])
+})
+
+test('batch keeps working when a listener throws during its flush', () => {
+  let $a = atom(0)
+  let $b = atom(0)
+  let log: string[] = []
+
+  $a.listen(() => {
+    throw new Error('boom')
+  })
+  $b.listen(value => log.push(`b=${value}`))
+
+  let threw = false
+  try {
+    batch(() => {
+      $a.set(1)
+      $b.set(1)
+    })
+  } catch {
+    threw = true
+  }
+
+  equal(threw, true)
+  deepStrictEqual(log, ['b=1'])
+
+  $b.set(2)
+  deepStrictEqual(log, ['b=1', 'b=2'])
+})
+
+test('keeps computed notified when an earlier listener throws', () => {
+  let $a = atom(0)
+  let $double = computed($a, a => a * 2)
+  let log: number[] = []
+
+  $a.listen(() => {
+    throw new Error('boom')
+  })
+  $double.listen(value => log.push(value))
+
+  try {
+    $a.set(5)
+  } catch {}
+
+  deepStrictEqual(log, [10])
+  equal($double.get(), 10)
+
+  try {
+    $a.set(6)
+  } catch {}
+
+  deepStrictEqual(log, [10, 12])
+  equal($double.get(), 12)
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nanostores",
   "version": "1.4.2",
-  "description": "A tiny (340 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
+  "description": "A tiny (368 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
   "keywords": [
     "preact",
     "react",
@@ -60,14 +60,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "340 B"
+      "limit": "368 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed }"
       },
-      "limit": "862 B"
+      "limit": "891 B"
     }
   ],
   "engines": {


### PR DESCRIPTION
## Overview

Fixes a bug where one throwing listener permanently stops every listener in the
application. Store values keep updating, so nothing looks broken until you
notice the UI has stopped moving.

## Problem Statement

`drainQueue` exits before `listenerQueue.length = 0` runs when a listener
throws. The queue stays non-empty for good. Every later `notify` sees a
non-empty queue, decides a drain is already in progress, pushes its listeners
and returns. From that point on no listener anywhere fires again.

```js
const $a = atom(0)
const $b = atom(0)

$a.listen(() => { throw new Error('boom') })
$b.listen(value => console.log('b listener saw', value))

try { $a.set(1) } catch {}

$b.set(2)
console.log('$b.value is', $b.value) // 2, correct
// the $b listener never ran, and never will
```

A page in this state cannot be recovered from user code. `batch(() => {})` does
call `drainQueue` from its `finally`, but the loop restarts at index 0, hits the
same entry and throws again. Unsubscribing the bad listener does not help
either: the unbind loop in `listen` starts at `lqIndex + QUEUE_ITEMS_PER_LISTENER`,
so it can never remove the entry at `lqIndex`, which is the one that threw.

The listener that throws belongs to the application, not to Nano Stores. But the
punishment lands somewhere else: an unrelated store goes quiet, values still look
right in the console, and nothing points back at the real throw. Anything that
listens broadly, such as a logger or a devtools bridge, is the most likely
casualty of a throw it had nothing to do with.

## Solution Approach

- `drainQueue` now runs each listener inside its own `try`, so one bad listener
  no longer stops the others. This matches what DOM events and `EventEmitter` do.
- The queue is always cleared, which restores the invariant that `notify` relies
  on. The application recovers on the next change.
- The first thrown value is rethrown once the queue is drained, so the error
  still reaches the caller of `set()`. It is held in a one-element array so that
  a falsy thrown value, for example `throw 0`, is not swallowed.
- `Atom` grows from 340 to 368 B and `Popular Set` from 862 to 891 B.

## Breaking Changes

No API changes. Two behavior changes follow from the fix:

- Listeners queued after a throwing one now run. Before, they were skipped.
- The error reaches the `set()` caller after the queue is drained instead of in
  the middle of it. When several listeners throw, the first thrown value is
  rethrown and the others are dropped.

## Testing

Six tests were added to `atom/index.test.ts`, each covering one part of the
contract:

- an unrelated store keeps working after a listener throws (the report above)
- listeners queued after a throwing one still run
- the first error is rethrown when several listeners throw
- a falsy thrown value still reaches the caller
- `batch` recovers when a listener throws during the flush from its `finally`,
  which is a different path from the existing test for a throwing batch body
- a `computed` keeps being notified when an earlier listener throws, and
  `get()` returns the correct value