### PR TITLE
Add eq and eqKey for custom value comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ export const Admins = () => {
   - [Maps](#maps)
   - [Lazy Stores](#lazy-stores)
   - [Computed Stores](#computed-stores)
+  - [Value Comparison](#value-comparison)
   - [Effects](#effects)
   - [Batching](#batching)
   - [Map Creator](#map-creator)
@@ -381,6 +382,46 @@ export const $newPosts = computed([$lastVisit, $posts], (lastVisit, posts) => {
   return posts.filter(post => post.publishedAt > lastVisit)
 })
 ```
+
+### Value Comparison
+
+Every store compares the old and the new value on `set()` with `Object.is()`.
+When the values are the same, the store keeps the old value and no listener
+is called.
+
+Set `store.eq` to compare values in your own way. It is useful for stores
+with objects or arrays inside, especially for computed stores, which create
+a new object on every run.
+
+```ts
+import equal from 'fast-deep-equal/es6'
+
+export const $visibleIds = computed($posts, posts => posts.map(post => post.id))
+$visibleIds.eq = equal
+```
+
+Now `$visibleIds` keeps its old array when the new one has the same items,
+so computed stores and components which depend on it will not be updated.
+
+Three things to keep in mind:
+
+- The old value can be `undefined` on the first call, for instance on the first
+  run of a computed store.
+- The function belongs to the store, so all its users share it.
+- `store.notify()` still calls listeners, even when values are equal.
+
+`map()` stores have a second function, `store.eqKey`, for `setKey()` calls.
+It receives two values of one key and the key name, because a single function
+serves every key of the map. The old value is `undefined` when the key is not
+in the map yet.
+
+```ts
+const $settings = map({ theme: 'dark', tags: [] })
+$settings.eqKey = equal
+```
+
+`store.set()` on a map uses `store.eq`, not `store.eqKey`. Deleting a key
+with `store.setKey(key, undefined)` does not compare values at all.
 
 ### Effects
 

--- a/atom/errors.ts
+++ b/atom/errors.ts
@@ -37,3 +37,8 @@ let readonlyAtom: ReadableAtom<string> = $store4
 let readonlyStore = readonlyType($store)
 // THROWS Property 'set' does not exist on type 'ReadableAtom
 readonlyStore.set({ value: 'no' })
+
+let $counter = atom(1)
+$counter.eq = (oldValue, newValue) => oldValue === newValue
+// THROWS is not assignable
+$counter.eq = (oldValue: string, newValue: string) => oldValue === newValue

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -17,6 +17,27 @@ export type ReadonlyIfObject<Value> = Value extends undefined
  */
 export interface ReadableAtom<Value = any> {
   /**
+   * Compares the previous and next values on every `set`.
+   *
+   * Returning `true` means the values are the same, so the store keeps the old
+   * value and no listener is called.
+   *
+   * @remarks
+   * Called only by the store's own writes, so a store that never writes never
+   * calls it. `Map#setKey` uses {@link MapStore#eqKey} instead.
+   *
+   * Before the first write, `oldValue` can be `undefined`, for instance on the
+   * first run of a computed store.
+   *
+   * @default Object.is
+   * @returns `true` if the values are equal, `false` otherwise.
+   */
+  eq(
+    oldValue: ReadonlyIfObject<Value>,
+    newValue: ReadonlyIfObject<Value>
+  ): boolean
+
+  /**
    * Get store value.
    *
    * In contrast with {@link ReadableAtom#value} this value will be always

--- a/atom/index.js
+++ b/atom/index.js
@@ -45,6 +45,7 @@ export const batch = fn => {
 export const atom = initialValue => {
   let listeners = []
   let $atom = {
+    eq: Object.is,
     get() {
       if (!$atom.lc) {
         $atom.listen(() => {})()
@@ -98,7 +99,7 @@ export const atom = initialValue => {
     off() {},
     set(newValue) {
       let oldValue = $atom.value
-      if (oldValue !== newValue) {
+      if (!$atom.eq(oldValue, newValue)) {
         $atom.value = newValue
         $atom.notify(oldValue)
       }

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -418,6 +418,48 @@ test('prevents notifying when new value is referentially equal to old one', () =
   clock.runAll()
 })
 
+test('compares values with Object.is by default', () => {
+  let events: number[] = []
+
+  let $store = atom(NaN)
+
+  let unbind = $store.listen(value => {
+    events.push(value)
+  })
+
+  $store.set(NaN)
+  deepStrictEqual(events, [])
+
+  $store.set(0)
+  $store.set(-0)
+  deepStrictEqual(events, [0, -0])
+
+  unbind()
+  clock.runAll()
+})
+
+test('uses custom eq to skip equal values', () => {
+  let events: { id: number }[] = []
+  let initial = { id: 1 }
+
+  let $store = atom(initial)
+  $store.eq = (oldValue, newValue) => oldValue.id === newValue.id
+
+  let unbind = $store.listen(value => {
+    events.push(value)
+  })
+
+  $store.set({ id: 1 })
+  deepStrictEqual(events, [])
+  equal($store.get(), initial)
+
+  $store.set({ id: 2 })
+  deepStrictEqual(events, [{ id: 2 }])
+
+  unbind()
+  clock.runAll()
+})
+
 test('can use previous value in listeners', () => {
   let events: (number | undefined)[] = []
   let $store = atom(0)

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -649,3 +649,52 @@ test('stale computed via nested dependency', () => {
   $event.set('foo')
   deepStrictEqual(values, [12])
 })
+
+test('eq on computed store stops downstream recomputations', () => {
+  let $source = atom(1)
+  let runs: string[] = []
+
+  let $flags = computed($source, value => {
+    runs.push('flags')
+    return [value > 0]
+  })
+  $flags.eq = (oldValue, newValue) =>
+    Array.isArray(oldValue) &&
+    oldValue.length === newValue.length &&
+    oldValue.every((flag, i) => flag === newValue[i])
+
+  let $label = computed($flags, flags => {
+    runs.push('label')
+    return flags[0] ? 'yes' : 'no'
+  })
+
+  let unbind = $label.subscribe(() => {})
+  deepStrictEqual(runs, ['flags', 'label'])
+
+  $source.set(2)
+  deepStrictEqual(runs, ['flags', 'label', 'flags'])
+  equal($label.get(), 'yes')
+
+  $source.set(-1)
+  deepStrictEqual(runs, ['flags', 'label', 'flags', 'flags', 'label'])
+  equal($label.get(), 'no')
+
+  unbind()
+  clock.runAll()
+})
+
+test('passes undefined as old value on the first computed run', () => {
+  let oldValues: unknown[] = []
+
+  let $source = atom(1)
+  let $double = computed($source, value => value * 2)
+  $double.eq = (oldValue, newValue) => {
+    oldValues.push(oldValue)
+    return Object.is(oldValue, newValue)
+  }
+
+  equal($double.get(), 2)
+  $source.set(3)
+  equal($double.get(), 6)
+  deepStrictEqual(oldValues, [undefined, 2])
+})

--- a/map/errors.ts
+++ b/map/errors.ts
@@ -43,3 +43,7 @@ $testIndexSignature.setKey('a', undefined)
 
 let $preinitialized = map()
 let initialValue: object = $preinitialized.value
+
+$test.eqKey = (oldValue, newValue, key) => key === 'id' || oldValue === newValue
+// THROWS is not assignable
+$test.eqKey = () => 'not a boolean'

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -47,6 +47,29 @@ export interface MapStore<
   Value extends object = any
 > extends WritableAtom<Value> {
   /**
+   * Compares the previous and next values for a key on every `setKey`.
+   *
+   * Returning `true` means the values are the same, so the store keeps the old
+   * value and no listener is called.
+   *
+   * One function serves every key of the map, so the key name comes as the
+   * third argument. The old value is `undefined` when the key is not in the map
+   * yet.
+   *
+   * @remarks
+   * Deleting a key with `setKey(key, undefined)` does not call it. Whole-value
+   * writes use {@link ReadableAtom#eq} instead.
+   *
+   * @default Object.is
+   * @returns `true` if the values are equal, `false` otherwise.
+   */
+  eqKey<Key extends AllKeys<Value>>(
+    oldValue: Get<Value, Key>,
+    newValue: Get<Value, Key>,
+    key: Key
+  ): boolean
+
+  /**
    * Subscribe to store changes.
    *
    * In contrast with {@link Store#subscribe} it do not call listener

--- a/map/index.js
+++ b/map/index.js
@@ -3,6 +3,7 @@ import { atom } from '../atom/index.js'
 /* @__NO_SIDE_EFFECTS__ */
 export const map = (initial = {}) => {
   let $map = atom(initial)
+  $map.eqKey = Object.is
 
   $map.setKey = function (key, value) {
     let oldMap = $map.value
@@ -10,7 +11,7 @@ export const map = (initial = {}) => {
       $map.value = { ...$map.value }
       delete $map.value[key]
       $map.notify(oldMap, key)
-    } else if ($map.value[key] !== value) {
+    } else if (!$map.eqKey($map.value[key], value, key)) {
       $map.value = {
         ...$map.value,
         [key]: value

--- a/map/index.test.ts
+++ b/map/index.test.ts
@@ -286,6 +286,30 @@ test('does not call listeners on no changes', () => {
   deepStrictEqual(changes, [undefined])
 })
 
+test('uses custom eqKey to skip equal key writes', () => {
+  let changes: (string | undefined)[] = []
+  let comparedKeys: string[] = []
+
+  let $store = map({ name: 'Ada' })
+  $store.eqKey = (oldValue, newValue, key) => {
+    comparedKeys.push(key)
+    return oldValue.toLowerCase() === newValue.toLowerCase()
+  }
+
+  $store.listen((_value, _oldValue, key) => {
+    changes.push(key)
+  })
+
+  $store.setKey('name', 'ADA')
+  deepStrictEqual(changes, [])
+  deepStrictEqual(comparedKeys, ['name'])
+  deepStrictEqual($store.get().name, 'Ada')
+
+  $store.setKey('name', 'Grace')
+  deepStrictEqual(changes, ['name'])
+  deepStrictEqual(comparedKeys, ['name', 'name'])
+})
+
 test('changes value object reference', () => {
   let $store = map({ a: 0 })
 
@@ -312,6 +336,62 @@ test('deletes keys on undefined value', () => {
   $store.setKey('a', 1)
   $store.setKey('a', undefined)
   deepStrictEqual(keys, [['a'], []])
+})
+
+test('uses eq for whole value writes and eqKey only for key writes', () => {
+  let eqKeyCalls = 0
+  let initial = { count: 1 }
+
+  let $store = map<{ count: number }>(initial)
+  $store.eq = (oldValue, newValue) => oldValue.count === newValue.count
+  $store.eqKey = () => {
+    eqKeyCalls += 1
+    return false
+  }
+
+  let changes: (string | undefined)[] = []
+  $store.listen((value, oldValue, key) => {
+    changes.push(key)
+  })
+
+  $store.set({ count: 1 })
+  deepStrictEqual(changes, [])
+  equal($store.get(), initial)
+  equal(eqKeyCalls, 0)
+
+  $store.set({ count: 2 })
+  deepStrictEqual(changes, [undefined])
+  equal(eqKeyCalls, 0)
+})
+
+test('passes undefined to eqKey for a key that is not set yet', () => {
+  let oldValues: unknown[] = []
+
+  let $store = map<{ a?: number }>({})
+  $store.eqKey = (oldValue, newValue) => {
+    oldValues.push(oldValue)
+    return Object.is(oldValue, newValue)
+  }
+
+  $store.listen(() => {})
+  $store.setKey('a', 1)
+
+  deepStrictEqual(oldValues, [undefined])
+  deepStrictEqual($store.get(), { a: 1 })
+})
+
+test('deletes keys even when eqKey says values are equal', () => {
+  let $store = map<{ a: number | undefined }>({ a: 1 })
+  $store.eqKey = () => true
+
+  let keys: string[][] = []
+  $store.listen(value => {
+    keys.push(Object.keys(value))
+  })
+
+  $store.setKey('a', 2)
+  $store.setKey('a', undefined)
+  deepStrictEqual(keys, [[]])
 })
 
 test('does not run queued listeners after they are unsubscribed', () => {

--- a/package.json
+++ b/package.json
@@ -60,14 +60,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "340 B"
+      "limit": "348 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed }"
       },
-      "limit": "862 B"
+      "limit": "885 B"
     }
   ],
   "engines": {


### PR DESCRIPTION
## Overview

Stores now keep the value comparison in a field instead of a hard-coded `!==`:
`store.eq(oldValue, newValue)` for `set()`, and `map.eqKey(oldValue, newValue, key)`
for `setKey()`. Both default to `Object.is`. Returning `true` means the values
are the same: no write, no notify, and the old value keeps its identity.

```js
import { dequal } from 'dequal/lite'

let $visibleIds = computed($posts, posts => posts.map(post => post.id))
$visibleIds.eq = dequal
```

## Problem Statement

A computed store builds its value from scratch on every run, so a derived array
or object always gets a new identity. Every store and component that depends on
it updates, even when the content did not change. The owner of the store cannot
prevent this from outside, because `computed` performs the write itself.

Issue #268 asked for the same thing as an option of `computed()` and was closed
with "it is better than making API complex with more options". A field is not an
option: it adds no argument to any factory, no overload to any signature, and
nothing to learn for people who never touch it.

Userland can already do this by replacing `set` on a store, and that stays
possible. Core support adds one thing that patching cannot: the check always
runs last, inside `set`, so it cannot land on the wrong side of an `onSet`
wrapper depending on which code ran first.

Using field approach and not option allowed making it compact: just 8 extra bytes for the atom. eq function as an option was giving around 25-30 bytes.

## Solution Approach

- `atom` gets an `eq` field, used by `set`. Default `Object.is`.
- `map` gets an `eqKey` field, used by `setKey`. Default `Object.is`. The key
  name comes as the third argument, because one function serves every key.
- `eq` is declared on `ReadableAtom`, so computed stores expose it. This is the
  main case, and `readonlyType()` already returns the same writable object.
- `map.set()` uses `eq`, `map.setKey()` uses `eqKey`. One function cannot serve
  both: `set` passes two whole store values, `setKey` passes two values of one
  key, and a comparison written for the object shape would silently drop key
  writes.
- Deleting a key with `setKey(key, undefined)` compares nothing, because
  removing a key changes the shape of the object, not a value.
- `deepMap` gets no `eqKey`, since it is deprecated and goes away in 2.0.

## Breaking Changes

The default comparison moves from `!==` to `Object.is`, which changes two corner
cases:

- writing `NaN` over `NaN` no longer calls listeners; today it calls them on
  every write;
- writing `0` over `-0` now calls listeners; today it does not.

IMO, we can neglect them.