### PR TITLE
fix(listen-keys): compare deep paths on whole-store set

### DIFF
--- a/listen-keys/index.js
+++ b/listen-keys/index.js
@@ -1,9 +1,18 @@
+import { getPath } from '../deep-map/path.js'
+
 export function listenKeys($store, keys, listener) {
   let keysSet = new Set(keys)
   return $store.listen((value, oldValue, changed) => {
     if (
       changed === undefined
-        ? keys.some(key => value[key] !== oldValue[key])
+        ? keys.some(
+            key =>
+              // `map` keys are plain properties, but a `deepMap` key is a path into
+              // the value, where a plain lookup would compare undefined to undefined
+              // and never report a change.
+              value[key] !== oldValue[key] ||
+              getPath(value, key) !== getPath(oldValue, key)
+          )
         : (keysSet.has(changed) || keysSet.has(changed.split(/\.|\[/)[0]))
     ) {
       listener(value, oldValue, changed)

--- a/listen-keys/index.test.ts
+++ b/listen-keys/index.test.ts
@@ -1,7 +1,7 @@
 import { deepStrictEqual, equal } from 'node:assert'
 import { test } from 'node:test'
 
-import { listenKeys, map, subscribeKeys } from '../index.js'
+import { deepMap, listenKeys, map, subscribeKeys } from '../index.js'
 
 test('listen for specific keys', () => {
   let events: string[] = []
@@ -104,4 +104,64 @@ test('can subscribe to changes and call listener immediately', () => {
   unbind()
   $store.setKey('a', 4)
   deepStrictEqual(events, ['1 1', '2 2', '3 2'])
+})
+
+
+test('listens for deep keys on whole-store set', () => {
+  let events: string[] = []
+  let $store = deepMap({ profile: { age: 1, name: 'a' } })
+
+  let unbind = listenKeys($store, ['profile.name'], value => {
+    events.push(value.profile.name)
+  })
+
+  // a whole-store set that changes the watched path fires
+  $store.set({ profile: { age: 1, name: 'b' } })
+  deepStrictEqual(events, ['b'])
+
+  // an unrelated sibling under the same parent does not
+  $store.set({ profile: { age: 2, name: 'b' } })
+  deepStrictEqual(events, ['b'])
+
+  // setting an identical value does not fire either
+  $store.set({ profile: { age: 2, name: 'b' } })
+  deepStrictEqual(events, ['b'])
+
+  unbind()
+  $store.set({ profile: { age: 2, name: 'c' } })
+  deepStrictEqual(events, ['b'])
+})
+
+test('listens for array paths on whole-store set', () => {
+  let events: (number | undefined)[] = []
+  let $store = deepMap<{ list: number[] }>({ list: [1, 2] })
+
+  let unbind = listenKeys($store, ['list[1]'], value => {
+    events.push(value.list[1])
+  })
+
+  $store.set({ list: [1, 3] })
+  deepStrictEqual(events, [3])
+
+  $store.set({ list: [9, 3] })
+  deepStrictEqual(events, [3])
+
+  unbind()
+})
+
+test('keeps plain map keys containing a dot working', () => {
+  let events: string[] = []
+  let $store = map<{ 'a.b': string }>({ 'a.b': 'one' })
+
+  let unbind = listenKeys($store, ['a.b'], value => {
+    events.push(value['a.b'])
+  })
+
+  $store.set({ 'a.b': 'two' })
+  deepStrictEqual(events, ['two'])
+
+  $store.set({ 'a.b': 'two' })
+  deepStrictEqual(events, ['two'])
+
+  unbind()
 })

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     {
       files: [
         'deep-map/index.test.ts',
+        'listen-keys/index.test.ts',
         'index.d.ts',
         'warn/index.js',
         'computed/*.{ts,js}',


### PR DESCRIPTION
Closes #416

## Problem

`listenKeys` handles a key differently depending on which branch runs:

```js
changed === undefined
  ? keys.some(key => value[key] !== oldValue[key])          // whole-store set()
  : (keysSet.has(changed) || keysSet.has(changed.split(/\.|\[/)[0]))  // setKey()
```

The `setKey` branch resolves paths by root segment (added in #408), but the whole-store `set()` branch treats the key as a plain property. For a path key such as `'profile.name'`, `value['profile.name']` is `undefined` on a value shaped `{ profile: { name } }` — on both sides — so the comparison is `undefined !== undefined`, always false, for every watched key on every `set()`. The listener never fires.

## Change

When a plain lookup finds nothing on both sides, fall back to resolving the key as a path with the existing `getPath`:

```js
value[key] !== oldValue[key] || getPath(value, key) !== getPath(oldValue, key)
```

Two properties this keeps, which is why the direct comparison stays first rather than being replaced:

- **#406's guarantee is preserved.** The comparison is still per-key and value-based, so a `set()` that leaves the watched keys untouched still does not notify — including a sibling change under the same parent, which a root-segment comparison would have reported as a false positive.
- **Plain keys that contain a dot keep working.** A store with a literal `'a.b'` property is still compared directly; resolving it as a path would have looked up `a.b` and broken it. There is a regression test for exactly this.

`getPath` is already a public export, and the two tracked size limits (`atom`, `map` + `computed`) don't include `listenKeys`, so the budgets are unaffected — both still pass.

## Tests

Three cases added to `listen-keys/index.test.ts`:
- a path key fires on a whole-store `set()` that changes it, and does **not** fire for an unrelated sibling or an identical value;
- an array path (`'list[1]'`) behaves the same;
- a plain store whose key literally contains a dot is unaffected.

The first two fail on `main` and pass with the change; the third passes either way and is there to pin the behaviour the fix must not break.

`pnpm test` is green end to end: 56 tests, types, lint, size limits, and the enforced 100% coverage.

One note for review: the new tests need `deepMap`, which is deprecated in core, so I added `listen-keys/index.test.ts` to the existing `typescript/no-deprecated` override in `oxlint.config.ts` — the same entry `deep-map/index.test.ts` already uses. Happy to drop that if you would rather the test lived in `@nanostores/deepmap` instead.