### PR TITLE
Align TypeScript declarations with runtime behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Store’s listeners will receive third argument with changed key.
 
 ```ts
 $profile.listen((profile, oldProfile, changed) => {
-  console.log(`${changed} new value ${profile[changed]}`)
+  if (changed) console.log(`${changed} new value ${profile[changed]}`)
 })
 ```
 

--- a/atom/errors.ts
+++ b/atom/errors.ts
@@ -51,3 +51,8 @@ let $counter = atom(1)
 $counter.eq = (oldValue, newValue) => oldValue === newValue
 // THROWS is not assignable
 $counter.eq = (oldValue: string, newValue: string) => oldValue === newValue
+$counter.eq = (oldValue, newValue) => {
+  // THROWS is possibly 'undefined'
+  oldValue.toFixed(2)
+  return oldValue !== undefined && oldValue === newValue
+}

--- a/atom/errors.ts
+++ b/atom/errors.ts
@@ -7,6 +7,15 @@ $store.listen(value => {
   value.value = 2
 })
 
+$store.listen((_, oldValue) => {
+  // THROWS is possibly 'undefined'
+  oldValue.value
+  if (oldValue !== undefined) {
+    let value: string = oldValue.value
+    console.log(value)
+  }
+})
+
 let $fnStore = atom<() => void>(() => {
   $fnStore.set(() => {})
 })

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -73,7 +73,7 @@ export interface ReadableAtom<Value = any> {
   listen(
     listener: (
       value: ReadonlyIfObject<Value>,
-      oldValue: ReadonlyIfObject<Value>
+      oldValue: ReadonlyIfObject<Value> | undefined
     ) => void
   ): () => void
 

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -33,7 +33,7 @@ export interface ReadableAtom<Value = any> {
    * @returns `true` if the values are equal, `false` otherwise.
    */
   eq(
-    oldValue: ReadonlyIfObject<Value>,
+    oldValue: ReadonlyIfObject<Value> | undefined,
     newValue: ReadonlyIfObject<Value>
   ): boolean
 

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -142,7 +142,6 @@ export interface PreinitializedWritableAtom<Value> extends WritableAtom<Value> {
 
 export type Atom<Value = any> = ReadableAtom<Value> | WritableAtom<Value>
 
-export declare let notifyId: number
 /**
  * Create store with atomic value. It could be a string or an object, which you
  * will replace completely.

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -443,7 +443,7 @@ test('uses custom eq to skip equal values', () => {
   let initial = { id: 1 }
 
   let $store = atom(initial)
-  $store.eq = (oldValue, newValue) => oldValue.id === newValue.id
+  $store.eq = (oldValue, newValue) => oldValue?.id === newValue.id
 
   let unbind = $store.listen(value => {
     events.push(value)

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -742,7 +742,7 @@ test('batch coalesces setKey on different keys into one undefined-key call', () 
 
 test('batch dedupes whole-store map.set notifications', () => {
   let $user = map({ age: 0, name: 'A' })
-  let calls: string[] = []
+  let calls: (string | undefined)[] = []
   let unbind = $user.listen((_v, _o, k) => calls.push(k))
 
   batch(() => {

--- a/computed/errors.ts
+++ b/computed/errors.ts
@@ -1,4 +1,5 @@
-import { computed, atom, task } from '../index.js'
+import { computed, atom, batched, task } from '../index.js'
+import type { StoreValues } from './index.js'
 
 let $word = atom<'a' | 'the'>('a')
 let $length = computed($word, word => word.length)
@@ -13,3 +14,23 @@ let $async = computed($word, word =>
 
 // THROWS Object is possibly 'undefined'
 console.log($async.get() + 1)
+
+let $count = atom(1)
+let origins = [$word, $count] as const
+
+let $label = computed(origins, (word, count) => word.repeat(count))
+let label: string = $label.get()
+
+let $batchedLabel = batched(origins, (word, count) => word.repeat(count))
+let batchedLabel: string = $batchedLabel.get()
+
+let $asyncLabel = computed(origins, (word, count) =>
+  task(async () => word.repeat(count))
+)
+// THROWS Object is possibly 'undefined'
+console.log($asyncLabel.get().length)
+
+let values: StoreValues<typeof origins> = ['the', 2]
+values[0] = 'a'
+
+console.log(label, batchedLabel, values)

--- a/computed/errors.ts
+++ b/computed/errors.ts
@@ -1,4 +1,4 @@
-import { computed, atom, batched, task } from '../index.js'
+import { computed, atom, type AnyStore, batched, task } from '../index.js'
 import type { StoreValues } from './index.js'
 
 let $word = atom<'a' | 'the'>('a')
@@ -34,3 +34,21 @@ let values: StoreValues<typeof origins> = ['the', 2]
 values[0] = 'a'
 
 console.log(label, batchedLabel, values)
+
+declare let $getOnly: AnyStore<number>
+// THROWS No overload matches this call
+computed([$getOnly], value => value)
+// THROWS No overload matches this call
+batched([$getOnly], value => value)
+
+// A source that only listens is not enough here: `computed` and `batched`
+// skip recomputing until the global epoch moves, and nothing but a real
+// Nano Store moves it.
+declare let $adapter: {
+  get(): number
+  listen(listener: () => void): () => void
+}
+// THROWS No overload matches this call
+computed([$adapter], value => value)
+// THROWS No overload matches this call
+computed($adapter, value => value)

--- a/computed/errors.ts
+++ b/computed/errors.ts
@@ -1,5 +1,11 @@
-import { computed, atom, type AnyStore, batched, task } from '../index.js'
-import type { StoreValues } from './index.js'
+import {
+  computed,
+  atom,
+  type AnyStore,
+  batched,
+  type StoreValues,
+  task
+} from '../index.js'
 
 let $word = atom<'a' | 'the'>('a')
 let $length = computed($word, word => word.length)
@@ -36,6 +42,9 @@ values[0] = 'a'
 console.log(label, batchedLabel, values)
 
 declare let $getOnly: AnyStore<number>
+let anyStoreValues: StoreValues<[typeof $getOnly]> = [1]
+// THROWS Type 'string' is not assignable to type 'number'
+let wrongAnyStoreValues: StoreValues<[typeof $getOnly]> = ['x']
 // THROWS No overload matches this call
 computed([$getOnly], value => value)
 // THROWS No overload matches this call
@@ -52,3 +61,5 @@ declare let $adapter: {
 computed([$adapter], value => value)
 // THROWS No overload matches this call
 computed($adapter, value => value)
+
+console.log(anyStoreValues, wrongAnyStoreValues)

--- a/computed/index.d.ts
+++ b/computed/index.d.ts
@@ -1,8 +1,8 @@
 import type { ReadableAtom } from '../atom/index.js'
-import type { ListenableStore, Store, StoreValue } from '../map/index.js'
+import type { Gettable, Store, StoreValue } from '../map/index.js'
 import type { Task } from '../task/index.js'
 
-export type StoreValues<Stores extends readonly ListenableStore[]> = {
+export type StoreValues<Stores extends readonly Gettable[]> = {
   -readonly [Index in keyof Stores]: StoreValue<Stores[Index]>
 }
 

--- a/computed/index.d.ts
+++ b/computed/index.d.ts
@@ -2,14 +2,9 @@ import type { ReadableAtom } from '../atom/index.js'
 import type { AnyStore, Store, StoreValue } from '../map/index.js'
 import type { Task } from '../task/index.js'
 
-export type StoreValues<Stores extends AnyStore[]> = {
-  [Index in keyof Stores]: StoreValue<Stores[Index]>
+export type StoreValues<Stores extends readonly AnyStore[]> = {
+  -readonly [Index in keyof Stores]: StoreValue<Stores[Index]>
 }
-
-type A = ReadableAtom<number>
-type B = ReadableAtom<string>
-
-type C = (...values: StoreValues<[A, B]>) => void
 
 interface Computed {
   /**
@@ -22,8 +17,8 @@ interface Computed {
   /**
    * @deprecated Use `@nanostores/async`.
    */
-  <Value, OriginStores extends AnyStore[]>(
-    stores: [...OriginStores],
+  <Value, OriginStores extends readonly AnyStore[]>(
+    stores: readonly [...OriginStores],
     cb: (...values: StoreValues<OriginStores>) => Task<Value>
   ): ReadableAtom<undefined | Value>
   <Value, OriginStore extends Store>(
@@ -45,8 +40,8 @@ interface Computed {
    *
    * Use `@nanostores/async` for async function.
    */
-  <Value, OriginStores extends AnyStore[]>(
-    stores: [...OriginStores],
+  <Value, OriginStores extends readonly AnyStore[]>(
+    stores: readonly [...OriginStores],
     cb: (...values: StoreValues<OriginStores>) => Task<Value> | Value
   ): ReadableAtom<Value>
 }
@@ -72,8 +67,8 @@ interface Batched {
    * })
    * ```
    */
-  <Value, OriginStores extends AnyStore[]>(
-    stores: [...OriginStores],
+  <Value, OriginStores extends readonly AnyStore[]>(
+    stores: readonly [...OriginStores],
     cb: (...values: StoreValues<OriginStores>) => Task<Value> | Value
   ): ReadableAtom<Value>
 }

--- a/computed/index.d.ts
+++ b/computed/index.d.ts
@@ -1,8 +1,8 @@
 import type { ReadableAtom } from '../atom/index.js'
-import type { AnyStore, Store, StoreValue } from '../map/index.js'
+import type { ListenableStore, Store, StoreValue } from '../map/index.js'
 import type { Task } from '../task/index.js'
 
-export type StoreValues<Stores extends readonly AnyStore[]> = {
+export type StoreValues<Stores extends readonly ListenableStore[]> = {
   -readonly [Index in keyof Stores]: StoreValue<Stores[Index]>
 }
 
@@ -17,7 +17,7 @@ interface Computed {
   /**
    * @deprecated Use `@nanostores/async`.
    */
-  <Value, OriginStores extends readonly AnyStore[]>(
+  <Value, OriginStores extends readonly Store[]>(
     stores: readonly [...OriginStores],
     cb: (...values: StoreValues<OriginStores>) => Task<Value>
   ): ReadableAtom<undefined | Value>
@@ -40,7 +40,7 @@ interface Computed {
    *
    * Use `@nanostores/async` for async function.
    */
-  <Value, OriginStores extends readonly AnyStore[]>(
+  <Value, OriginStores extends readonly Store[]>(
     stores: readonly [...OriginStores],
     cb: (...values: StoreValues<OriginStores>) => Task<Value> | Value
   ): ReadableAtom<Value>
@@ -67,7 +67,7 @@ interface Batched {
    * })
    * ```
    */
-  <Value, OriginStores extends readonly AnyStore[]>(
+  <Value, OriginStores extends readonly Store[]>(
     stores: readonly [...OriginStores],
     cb: (...values: StoreValues<OriginStores>) => Task<Value> | Value
   ): ReadableAtom<Value>

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -316,7 +316,7 @@ test('prevents dependency listeners from being out of order', () => {
   unsubscribe()
 })
 
-test('notifies when stores change within the same notifyId', () => {
+test('notifies when a listener updates the source store', () => {
   let $val = atom(1)
 
   let $computed1 = computed($val, val => {

--- a/deep-map/errors.ts
+++ b/deep-map/errors.ts
@@ -14,7 +14,13 @@ test.subscribe((_, __, changedKey) => {
   }
 })
 
-test.listen((_, __, changedKey) => {
+test.listen((_, oldValue, changedKey) => {
+  // THROWS is possibly 'undefined'
+  oldValue.isLoading
+  if (oldValue !== undefined) {
+    let loading: boolean = oldValue.isLoading
+    console.log(loading)
+  }
   if (changedKey === 'a') {
   }
   // THROWS have no overlap

--- a/deep-map/index.d.ts
+++ b/deep-map/index.d.ts
@@ -24,9 +24,7 @@ export type DeepMapStore<T extends BaseDeepMap> = {
    * immediately.
    *
    * @param listener Callback with store value and old value.
-   * @param changedKey Key that was changed. Will present only if `setKey`
-   *                   has been used to change a store. It is `undefined` when
-   *                   changes were coalesced inside `batch`.
+   * @param changedKey Key that changed, when the notification carries one.
    * @returns Function to remove listener.
    */
   listen(
@@ -75,9 +73,7 @@ export type DeepMapStore<T extends BaseDeepMap> = {
    * ```
    *
    * @param listener Callback with store value and old value.
-   * @param changedKey Key that was changed. Will present only
-   *                   if `setKey` has been used to change a store. It is
-   *                   `undefined` when changes were coalesced inside `batch`.
+   * @param changedKey Key that changed, when the notification carries one.
    * @returns Function to remove listener.
    */
   subscribe(

--- a/deep-map/index.d.ts
+++ b/deep-map/index.d.ts
@@ -32,7 +32,7 @@ export type DeepMapStore<T extends BaseDeepMap> = {
   listen(
     listener: (
       value: T,
-      oldValue: T,
+      oldValue: T | undefined,
       changedKey: AllPaths<T> | undefined
     ) => void
   ): () => void

--- a/deep-map/index.test.ts
+++ b/deep-map/index.test.ts
@@ -352,7 +352,7 @@ test('notifies correct previous value from deep store', () => {
 })
 
 test('passes previous value to listeners', () => {
-  let events: { a: number }[] = []
+  let events: ({ a: number } | undefined)[] = []
   let $store = deepMap({ a: 0 })
   let unbind = $store.listen((value, oldValue) => {
     events.push(oldValue)

--- a/deep-map/index.test.ts
+++ b/deep-map/index.test.ts
@@ -327,19 +327,22 @@ test('does not run queued listeners after they are unsubscribed', () => {
 test('notifies correct previous value from deep store', () => {
   type DeepValue = { a: number; b: { nested: { deep: number } } }
 
+  let changes: (string | undefined)[] = []
   let events: (DeepValue | undefined)[] = []
   let $store = deepMap({
     a: 0,
     b: { nested: { deep: 0 } }
   })
 
-  let unbind = onNotify($store, ({ oldValue }) => {
+  let unbind = onNotify($store, ({ changed, oldValue }) => {
+    changes.push(changed)
     events.push(oldValue)
   })
 
   $store.setKey('a', 1)
   $store.setKey('b.nested.deep', 1)
   $store.setKey('b.nested.deep', 2)
+  deepStrictEqual(changes, ['a', 'b.nested.deep', 'b.nested.deep'])
   deepStrictEqual(events, [
     { a: 0, b: { nested: { deep: 0 } } },
     { a: 1, b: { nested: { deep: 0 } } },

--- a/deep-map/index.test.ts
+++ b/deep-map/index.test.ts
@@ -327,7 +327,7 @@ test('does not run queued listeners after they are unsubscribed', () => {
 test('notifies correct previous value from deep store', () => {
   type DeepValue = { a: number; b: { nested: { deep: number } } }
 
-  let events: DeepValue[] = []
+  let events: (DeepValue | undefined)[] = []
   let $store = deepMap({
     a: 0,
     b: { nested: { deep: 0 } }

--- a/effect/errors.ts
+++ b/effect/errors.ts
@@ -1,4 +1,5 @@
 import { atom } from '../atom/index.js'
+import type { AnyStore } from '../map/index.js'
 import { effect } from './index.js'
 
 let $first = atom('Tony')
@@ -15,4 +16,21 @@ let origins = [$first, $age] as const
 effect(origins, (first, age) => {
   let firstStr: string = first
   let ageNum: number = age
+})
+
+declare let $getOnly: AnyStore<number>
+// THROWS No overload matches this call
+effect([$getOnly], () => {})
+
+// `effect` reruns straight from the listener, so an adapter that can only
+// be read and listened to is a complete source here.
+declare let $adapter: {
+  get(): number
+  listen(listener: () => void): () => void
+}
+effect($adapter, value => {
+  let num: number = value
+})
+effect([$adapter, $age], (value, age) => {
+  let num: number = value + age
 })

--- a/effect/errors.ts
+++ b/effect/errors.ts
@@ -10,3 +10,9 @@ effect([$first, $last, $age], (first, last, age) => {
   let lastStr: string = last
   let ageNum: number = age
 })
+
+let origins = [$first, $age] as const
+effect(origins, (first, age) => {
+  let firstStr: string = first
+  let ageNum: number = age
+})

--- a/effect/index.d.ts
+++ b/effect/index.d.ts
@@ -1,8 +1,8 @@
 import type { StoreValues } from '../computed/index.js'
-import type { AnyStore, Store, StoreValue } from '../index.js'
+import type { ListenableStore, StoreValue } from '../index.js'
 
 interface Effect {
-  <OriginStore extends Store>(
+  <OriginStore extends ListenableStore>(
     stores: OriginStore,
     cb: (value: StoreValue<OriginStore>) => (() => void) | void
   ): () => void
@@ -25,7 +25,7 @@ interface Effect {
    * })
    * ```
    */
-  <OriginStores extends readonly AnyStore[]>(
+  <OriginStores extends readonly ListenableStore[]>(
     stores: readonly [...OriginStores],
     cb: (...values: StoreValues<OriginStores>) => (() => void) | void
   ): () => void

--- a/effect/index.d.ts
+++ b/effect/index.d.ts
@@ -1,4 +1,4 @@
-import type { StoreValues } from '../computed/index.d.ts'
+import type { StoreValues } from '../computed/index.js'
 import type { AnyStore, Store, StoreValue } from '../index.js'
 
 interface Effect {
@@ -25,8 +25,8 @@ interface Effect {
    * })
    * ```
    */
-  <OriginStores extends AnyStore[]>(
-    stores: [...OriginStores],
+  <OriginStores extends readonly AnyStore[]>(
+    stores: readonly [...OriginStores],
     cb: (...values: StoreValues<OriginStores>) => (() => void) | void
   ): () => void
 }

--- a/effect/index.test.ts
+++ b/effect/index.test.ts
@@ -1,4 +1,4 @@
-import { strictEqual } from 'node:assert'
+import { deepStrictEqual, strictEqual } from 'node:assert'
 import type { Mock, TestContext } from 'node:test'
 import { test } from 'node:test'
 
@@ -84,4 +84,27 @@ test('Stops running effect when returned unsubscribe method called. Runs effect 
   strictEqual(effectCleanupMock.mock.calls.length, 1)
   $atom1.set(30)
   strictEqual(effectCleanupMock.mock.calls.length, 1)
+})
+
+test('Supports listenable sources', () => {
+  let value = 1
+  let listeners = new Set<() => void>()
+  let $source = {
+    get: () => value,
+    listen(listener: () => void) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    }
+  }
+  let values: number[] = []
+
+  let unbind = effect($source, current => {
+    values.push(current)
+  })
+  value = 2
+  for (let listener of listeners) listener()
+
+  deepStrictEqual(values, [1, 2])
+  unbind()
+  strictEqual(listeners.size, 0)
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,8 @@ export { listenKeys, subscribeKeys } from './listen-keys/index.js'
 export { mapCreator, MapCreator } from './map-creator/index.js'
 export {
   AnyStore,
+  Gettable,
+  ListenableStore,
   map,
   MapStore,
   MapStoreKeys,

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export {
   WritableAtom
 } from './atom/index.js'
 export { clean, cleanStores } from './clean-stores/index.js'
-export { batched, computed } from './computed/index.js'
+export { batched, computed, StoreValues } from './computed/index.js'
 export {
   AllPaths,
   BaseDeepMap,

--- a/lifecycle/errors.ts
+++ b/lifecycle/errors.ts
@@ -1,0 +1,17 @@
+import { atom, onMount } from '../index.js'
+
+let $store = atom(0)
+
+onMount($store, () => {})
+
+onMount($store, () => {
+  return () => {}
+})
+
+onMount<{ mounts: number }>($store, ({ shared }) => {
+  let mounts: number = shared.mounts
+  console.log(mounts)
+})
+
+// THROWS Expected 2 arguments, but got 1
+onMount($store)

--- a/lifecycle/errors.ts
+++ b/lifecycle/errors.ts
@@ -1,4 +1,4 @@
-import { atom, map, onMount, onNotify, onSet } from '../index.js'
+import { atom, deepMap, map, onMount, onNotify, onSet } from '../index.js'
 
 type TestType =
   | { id: string; isLoading: true }
@@ -7,6 +7,7 @@ type TestType =
 let $store = atom(0)
 let $map = map({ count: 0 })
 let $unionMap = map<TestType>({ id: '', isLoading: true })
+let $deepMap = deepMap({ a: 0, b: { nested: { deep: 0 } } })
 
 onMount($store, () => {})
 
@@ -70,4 +71,20 @@ onNotify($unionMap, ({ changed }) => {
   // THROWS is not assignable to type
   let unknownKey: typeof changed = 'z'
   console.log(branchKey, optionalKey, unknownKey)
+})
+
+// Deep maps use the same lifecycle payloads as maps, but their `setKey`
+// contract carries full paths rather than only top-level keys.
+onSet($deepMap, ({ changed }) => {
+  let nestedPath: typeof changed = 'b.nested.deep'
+  // THROWS is not assignable to type
+  let unknownPath: typeof changed = 'b.unknown'
+  console.log(nestedPath, unknownPath)
+})
+
+onNotify($deepMap, ({ changed }) => {
+  let nestedPath: typeof changed = 'b.nested.deep'
+  // THROWS is not assignable to type
+  let unknownPath: typeof changed = 'b.unknown'
+  console.log(nestedPath, unknownPath)
 })

--- a/lifecycle/errors.ts
+++ b/lifecycle/errors.ts
@@ -1,7 +1,12 @@
 import { atom, map, onMount, onNotify, onSet } from '../index.js'
 
+type TestType =
+  | { id: string; isLoading: true }
+  | { isLoading: false; a: string; b: number; c?: number }
+
 let $store = atom(0)
 let $map = map({ count: 0 })
+let $unionMap = map<TestType>({ id: '', isLoading: true })
 
 onMount($store, () => {})
 
@@ -46,4 +51,23 @@ onNotify($map, ({ abort, changed, oldValue }) => {
   changed.toString()
   // THROWS is possibly 'undefined'
   oldValue.count
+})
+
+// `setKey` accepts a key from any branch of a union value, and the runtime
+// forwards it, so the payload has to accept every branch's keys too — not
+// only the ones all branches share.
+onSet($unionMap, ({ changed }) => {
+  let branchKey: typeof changed = 'a'
+  let sharedKey: typeof changed = 'isLoading'
+  console.log(branchKey, sharedKey)
+})
+
+onNotify($unionMap, ({ changed }) => {
+  let branchKey: typeof changed = 'b'
+  let optionalKey: typeof changed = 'c'
+  // Not a guard on the union fix — `'z'` is rejected either way. This one
+  // is here so the key type cannot quietly widen to `string`.
+  // THROWS is not assignable to type
+  let unknownKey: typeof changed = 'z'
+  console.log(branchKey, optionalKey, unknownKey)
 })

--- a/lifecycle/errors.ts
+++ b/lifecycle/errors.ts
@@ -1,6 +1,7 @@
-import { atom, onMount } from '../index.js'
+import { atom, map, onMount, onNotify, onSet } from '../index.js'
 
 let $store = atom(0)
+let $map = map({ count: 0 })
 
 onMount($store, () => {})
 
@@ -15,3 +16,34 @@ onMount<{ mounts: number }>($store, ({ shared }) => {
 
 // THROWS Expected 2 arguments, but got 1
 onMount($store)
+
+onSet($store, ({ abort, changed, newValue }) => {
+  abort()
+  let key: undefined = changed
+  let value: number = newValue
+  console.log(key, value)
+})
+
+onNotify($store, ({ abort, changed, oldValue }) => {
+  abort()
+  let key: undefined = changed
+  // THROWS is not assignable to type 'number'
+  let value: number = oldValue
+  console.log(key, value)
+})
+
+onSet($map, ({ abort, changed, newValue }) => {
+  abort()
+  let value: number = newValue.count
+  // THROWS is possibly 'undefined'
+  changed.toString()
+  console.log(value)
+})
+
+onNotify($map, ({ abort, changed, oldValue }) => {
+  abort()
+  // THROWS is possibly 'undefined'
+  changed.toString()
+  // THROWS is possibly 'undefined'
+  oldValue.count
+})

--- a/lifecycle/index.d.ts
+++ b/lifecycle/index.d.ts
@@ -19,7 +19,7 @@ type MapSetPayload<Shared, SomeStore extends Store> =
 type AtomNotifyPayload<Shared, SomeStore extends Store> = {
   abort(): void
   changed: undefined
-  oldValue: StoreValue<SomeStore>
+  oldValue: StoreValue<SomeStore> | undefined
   shared: Shared
 }
 
@@ -27,7 +27,7 @@ type MapNotifyPayload<Shared, SomeStore extends Store> =
   | {
       abort(): void
       changed: keyof StoreValue<SomeStore>
-      oldValue: StoreValue<SomeStore>
+      oldValue: StoreValue<SomeStore> | undefined
       shared: Shared
     }
   | AtomNotifyPayload<Shared, SomeStore>

--- a/lifecycle/index.d.ts
+++ b/lifecycle/index.d.ts
@@ -1,3 +1,4 @@
+import type { AllKeys } from '../atom/index.js'
 import type { MapStore, Store, StoreValue } from '../map/index.js'
 
 type AtomSetPayload<Shared, SomeStore extends Store> = {
@@ -10,7 +11,7 @@ type AtomSetPayload<Shared, SomeStore extends Store> = {
 type MapSetPayload<Shared, SomeStore extends Store> =
   | {
       abort(): void
-      changed: keyof StoreValue<SomeStore>
+      changed: AllKeys<StoreValue<SomeStore>>
       newValue: StoreValue<SomeStore>
       shared: Shared
     }
@@ -26,7 +27,7 @@ type AtomNotifyPayload<Shared, SomeStore extends Store> = {
 type MapNotifyPayload<Shared, SomeStore extends Store> =
   | {
       abort(): void
-      changed: keyof StoreValue<SomeStore>
+      changed: AllKeys<StoreValue<SomeStore>>
       oldValue: StoreValue<SomeStore> | undefined
       shared: Shared
     }

--- a/lifecycle/index.d.ts
+++ b/lifecycle/index.d.ts
@@ -150,5 +150,5 @@ export const STORE_UNMOUNT_DELAY: number
  */
 export function onMount<Shared = never>(
   $store: Store,
-  initialize?: (payload: { shared: Shared }) => (() => void) | void
+  initialize: (payload: { shared: Shared }) => (() => void) | void
 ): () => void

--- a/lifecycle/index.d.ts
+++ b/lifecycle/index.d.ts
@@ -1,5 +1,6 @@
-import type { AllKeys } from '../atom/index.js'
-import type { MapStore, Store, StoreValue } from '../map/index.js'
+import type { MapStoreKeys, Store, StoreValue } from '../map/index.js'
+
+type KeyedStore = Store & { setKey: (...args: any[]) => any }
 
 type AtomSetPayload<Shared, SomeStore extends Store> = {
   abort(): void
@@ -11,7 +12,7 @@ type AtomSetPayload<Shared, SomeStore extends Store> = {
 type MapSetPayload<Shared, SomeStore extends Store> =
   | {
       abort(): void
-      changed: AllKeys<StoreValue<SomeStore>>
+      changed: MapStoreKeys<SomeStore>
       newValue: StoreValue<SomeStore>
       shared: Shared
     }
@@ -27,7 +28,7 @@ type AtomNotifyPayload<Shared, SomeStore extends Store> = {
 type MapNotifyPayload<Shared, SomeStore extends Store> =
   | {
       abort(): void
-      changed: AllKeys<StoreValue<SomeStore>>
+      changed: MapStoreKeys<SomeStore>
       oldValue: StoreValue<SomeStore> | undefined
       shared: Shared
     }
@@ -59,7 +60,7 @@ type MapNotifyPayload<Shared, SomeStore extends Store> =
 export function onSet<Shared = never, SomeStore extends Store = Store>(
   $store: SomeStore,
   listener: (
-    payload: SomeStore extends MapStore
+    payload: SomeStore extends KeyedStore
       ? MapSetPayload<Shared, SomeStore>
       : AtomSetPayload<Shared, SomeStore>
   ) => void
@@ -80,7 +81,7 @@ export function onSet<Shared = never, SomeStore extends Store = Store>(
 export function onNotify<Shared = never, SomeStore extends Store = Store>(
   $store: SomeStore,
   listener: (
-    payload: SomeStore extends MapStore
+    payload: SomeStore extends KeyedStore
       ? MapNotifyPayload<Shared, SomeStore>
       : AtomNotifyPayload<Shared, SomeStore>
   ) => void

--- a/lifecycle/index.test.ts
+++ b/lifecycle/index.test.ts
@@ -235,7 +235,7 @@ test('supports map in onSet and onNotify', () => {
     }
   })
   onNotify(store, e => {
-    events.push(`notify ${e.changed} ${e.oldValue.value}`)
+    events.push(`notify ${e.changed} ${e.oldValue?.value}`)
   })
 
   store.subscribe((value, oldValue, changed) => {

--- a/listen-keys/errors.ts
+++ b/listen-keys/errors.ts
@@ -7,7 +7,7 @@ type TestType =
 
 type TestKey = 'a' | 'b' | 'c' | 'id' | 'isLoading'
 
-let test = map<TestType>()
+let test = map<TestType>({ id: '', isLoading: true })
 
 listenKeys(test, ['a', 'b', 'c'], (_, __, changed) => {
   // THROWS is possibly 'undefined'

--- a/listen-keys/errors.ts
+++ b/listen-keys/errors.ts
@@ -9,7 +9,13 @@ type TestKey = 'a' | 'b' | 'c' | 'id' | 'isLoading'
 
 let test = map<TestType>({ id: '', isLoading: true })
 
-listenKeys(test, ['a', 'b', 'c'], (_, __, changed) => {
+listenKeys(test, ['a', 'b', 'c'], (_, oldValue, changed) => {
+  // THROWS is possibly 'undefined'
+  oldValue.isLoading
+  if (oldValue !== undefined) {
+    let loading: boolean = oldValue.isLoading
+    console.log(loading)
+  }
   // THROWS is possibly 'undefined'
   changed.toUpperCase()
   if (changed !== undefined) {

--- a/listen-keys/errors.ts
+++ b/listen-keys/errors.ts
@@ -1,13 +1,33 @@
 import { map, WritableAtom } from '../index.js'
-import { listenKeys } from './index.js'
+import { listenKeys, subscribeKeys } from './index.js'
 
 type TestType =
   | { id: string; isLoading: true }
   | { isLoading: false; a: string; b: number; c?: number }
 
+type TestKey = 'a' | 'b' | 'c' | 'id' | 'isLoading'
+
 let test = map<TestType>()
 
-listenKeys(test, ['a', 'b', 'c'], () => {})
+listenKeys(test, ['a', 'b', 'c'], (_, __, changed) => {
+  // THROWS is possibly 'undefined'
+  changed.toUpperCase()
+  if (changed !== undefined) {
+    let key: TestKey = changed
+    console.log(key)
+  }
+})
+
+subscribeKeys(test, ['a'], (_, oldValue, changed) => {
+  // THROWS is possibly 'undefined'
+  oldValue.isLoading
+  // THROWS is possibly 'undefined'
+  changed.toUpperCase()
+  if (changed !== undefined) {
+    let key: TestKey = changed
+    console.log(key)
+  }
+})
 
 // THROWS is not assignable
 listenKeys(test, ['unknownKey'], () => {})
@@ -16,7 +36,14 @@ declare let $fakeStore: {
   setKey: (key: 'hey' | 'you', value?: boolean | string) => void
 } & WritableAtom<null>
 
-listenKeys($fakeStore, ['hey', 'you'], () => {})
+listenKeys($fakeStore, ['hey', 'you'], (_, __, changed) => {
+  // THROWS is possibly 'undefined'
+  changed.toUpperCase()
+  if (changed !== undefined) {
+    let key: 'hey' | 'you' = changed
+    console.log(key)
+  }
+})
 
 // THROWS is not assignable
 listenKeys($fakeStore, ['unknownKey'], () => {})

--- a/listen-keys/index.d.ts
+++ b/listen-keys/index.d.ts
@@ -1,4 +1,4 @@
-import type { StoreValue } from '../map/index.js'
+import type { MapStoreKeys, StoreValue } from '../map/index.js'
 
 /**
  * Listen for specific keys of the store.
@@ -23,17 +23,11 @@ export function listenKeys<
   SomeStore extends { setKey: (key: any, value: any) => void }
 >(
   $store: SomeStore,
-  keys: SomeStore extends { setKey: (key: infer Key, value: never) => unknown }
-    ? readonly Key[]
-    : never,
+  keys: readonly MapStoreKeys<SomeStore>[],
   listener: (
     value: StoreValue<SomeStore>,
     oldValue: StoreValue<SomeStore>,
-    changed: SomeStore extends {
-      setKey: (key: infer Key, value: never) => unknown
-    }
-      ? Key[]
-      : never
+    changed: MapStoreKeys<SomeStore> | undefined
   ) => void
 ): () => void
 
@@ -60,16 +54,10 @@ export function subscribeKeys<
   SomeStore extends { setKey: (key: any, value: any) => void }
 >(
   $store: SomeStore,
-  keys: SomeStore extends { setKey: (key: infer Key, value: never) => unknown }
-    ? readonly Key[]
-    : never,
+  keys: readonly MapStoreKeys<SomeStore>[],
   listener: (
     value: StoreValue<SomeStore>,
-    oldValue: StoreValue<SomeStore>,
-    changed: SomeStore extends {
-      setKey: (key: infer Key, value: never) => unknown
-    }
-      ? Key[]
-      : never
+    oldValue: StoreValue<SomeStore> | undefined,
+    changed: MapStoreKeys<SomeStore> | undefined
   ) => void
 ): () => void

--- a/listen-keys/index.d.ts
+++ b/listen-keys/index.d.ts
@@ -26,7 +26,7 @@ export function listenKeys<
   keys: readonly MapStoreKeys<SomeStore>[],
   listener: (
     value: StoreValue<SomeStore>,
-    oldValue: StoreValue<SomeStore>,
+    oldValue: StoreValue<SomeStore> | undefined,
     changed: MapStoreKeys<SomeStore> | undefined
   ) => void
 ): () => void

--- a/listen-keys/index.js
+++ b/listen-keys/index.js
@@ -7,6 +7,7 @@ export function listenKeys($store, keys, listener) {
       changed === undefined
         ? keys.some(
             key =>
+              oldValue === undefined ||
               // `map` keys are plain properties, but a `deepMap` key is a path into
               // the value, where a plain lookup would compare undefined to undefined
               // and never report a change.

--- a/listen-keys/index.test.ts
+++ b/listen-keys/index.test.ts
@@ -80,6 +80,48 @@ test('fires for whole-store set when a watched key is removed', () => {
   deepStrictEqual(events, ['undefined'])
 })
 
+test('fires when a notification carries no old value', () => {
+  let events: string[] = []
+  let $store = map({ a: 1, b: 2 })
+
+  listenKeys($store, ['a'], (value, oldValue, changed) => {
+    events.push(`${value.a} ${oldValue?.a} ${changed}`)
+  })
+  deepStrictEqual(events, [])
+
+  // Nothing to compare against, so a watched key may have changed
+  $store.notify()
+  deepStrictEqual(events, ['1 undefined undefined'])
+})
+
+test('never fires without watched keys', () => {
+  let events: string[] = []
+  let $store = map({ a: 1, b: 2 })
+
+  listenKeys($store, [], (value, oldValue, changed) => {
+    events.push(`${value.a} ${oldValue?.a} ${changed}`)
+  })
+
+  $store.notify()
+  $store.set({ a: 9, b: 9 })
+  deepStrictEqual(events, [])
+})
+
+test('filters by key when a keyed notification carries no old value', () => {
+  let events: string[] = []
+  let $store = map({ a: 1, b: 2 })
+
+  listenKeys($store, ['a'], (value, oldValue, changed) => {
+    events.push(`${value.a} ${oldValue?.a} ${changed}`)
+  })
+
+  $store.notify(undefined, 'a')
+  deepStrictEqual(events, ['1 undefined a'])
+
+  $store.notify(undefined, 'b')
+  deepStrictEqual(events, ['1 undefined a'])
+})
+
 test('can subscribe to changes and call listener immediately', () => {
   let events: string[] = []
   let $store = map({ a: 1, b: 1 })

--- a/map-creator/errors.ts
+++ b/map-creator/errors.ts
@@ -1,0 +1,39 @@
+import { mapCreator } from '../index.js'
+
+let User = mapCreator<
+  { name: string },
+  [boolean],
+  { rename(name: string): void }
+>((store, id, admin) => {
+  store.set({ id, name: admin ? 'Admin' : 'User' })
+  store.rename = name => {
+    store.setKey('name', name)
+  }
+})
+
+// `id` is set when the store is built, so every path exposes it.
+let user = User('1', true)
+let id: string = user.get().id
+
+let built = User.build('2', false)
+let builtId: string = built.get().id
+
+let cached = User.cache['1']
+let cachedId: undefined | string = cached?.get().id
+
+// `rename` is assigned by the initializer, so a store that has not mounted
+// yet does not have it.
+// THROWS Property 'rename' does not exist
+user.rename('New name')
+// THROWS Property 'rename' does not exist
+User.cache['1']?.rename('New name')
+
+// Without a declared `StoreExt`, the initializer's store has no arbitrary
+// properties either.
+mapCreator<{ name: string }>((store, defaultId) => {
+  store.set({ id: defaultId, name: 'User' })
+  // THROWS Property 'notAThing' does not exist
+  store.notAThing
+})
+
+console.log(id, builtId, cachedId)

--- a/map-creator/index.d.ts
+++ b/map-creator/index.d.ts
@@ -4,8 +4,8 @@ export interface MapCreator<
   Value extends object = any,
   Args extends any[] = []
 > {
-  (id: string, ...args: Args): MapStore<Value>
-  build(id: string, ...args: Args): MapStore<Value>
+  (id: string, ...args: Args): MapStore<{ id: string } & Value>
+  build(id: string, ...args: Args): MapStore<{ id: string } & Value>
   cache: {
     [id: string]: MapStore<{ id: string } & Value>
   }
@@ -19,7 +19,7 @@ export interface MapCreator<
 export function mapCreator<
   Value extends object,
   Args extends any[] = [],
-  StoreExt = Record<number | string | symbol, any>
+  StoreExt extends object = object
 >(
   init?: (
     store: MapStore<{ id: string } & Value> & StoreExt,

--- a/map/errors.ts
+++ b/map/errors.ts
@@ -1,4 +1,4 @@
-import { map } from '../index.js'
+import { map, type MapStoreKeys } from '../index.js'
 
 type TestType =
   | { id: string; isLoading: true }
@@ -88,10 +88,19 @@ let initializedValue: string = $initialized.get().a
 // THROWS Argument of type 'undefined' is not assignable to parameter
 $initialized.set(undefined)
 
+let $extended = map<
+  { a: number; b: string },
+  { setKey: (key: 'ext', value: number) => void }
+>({ a: 0, b: '' })
+let extendedKey: MapStoreKeys<typeof $extended> = 'a'
+// THROWS Type '"ext"' is not assignable to type '"a" | "b"'
+extendedKey = 'ext'
+
 console.log(
   partialValue,
   missingValue,
   explicitValue,
   maybeValue,
-  initializedValue
+  initializedValue,
+  extendedKey
 )

--- a/map/errors.ts
+++ b/map/errors.ts
@@ -56,6 +56,15 @@ $test.eqKey = (oldValue, newValue, key) => key === 'id' || oldValue === newValue
 // THROWS is not assignable
 $test.eqKey = () => 'not a boolean'
 
+let $counted = map({ a: 1 })
+$counted.eqKey = (oldValue, newValue, key) => {
+  // THROWS is possibly 'undefined'
+  oldValue.toFixed(2)
+  // THROWS is possibly 'undefined'
+  newValue.toFixed(2)
+  return key === 'a' && oldValue === newValue
+}
+
 // An empty map still accepts every key of the union, and every branch of
 // the union is still a legal whole value.
 let $partialUnion = map<TestType>()

--- a/map/errors.ts
+++ b/map/errors.ts
@@ -14,7 +14,13 @@ $test.subscribe((_, __, changedKey) => {
   }
 })
 
-$test.listen((_, __, changedKey) => {
+$test.listen((_, oldValue, changedKey) => {
+  // THROWS is possibly 'undefined'
+  oldValue.isLoading
+  if (oldValue !== undefined) {
+    let loading: boolean = oldValue.isLoading
+    console.log(loading)
+  }
   if (changedKey === 'a') {
   }
   // THROWS have no overlap

--- a/map/errors.ts
+++ b/map/errors.ts
@@ -20,6 +20,8 @@ $test.listen((_, __, changedKey) => {
   // THROWS have no overlap
   if (changedKey === 'z') {
   }
+  // THROWS is possibly 'undefined'
+  changedKey.toString()
 })
 
 $test.setKey('isLoading', true)

--- a/map/errors.ts
+++ b/map/errors.ts
@@ -4,7 +4,7 @@ type TestType =
   | { id: string; isLoading: true }
   | { isLoading: false; a: string; b: number; c?: number }
 
-let $test = map<TestType>()
+let $test = map<TestType>({ id: '', isLoading: true })
 
 $test.subscribe((_, __, changedKey) => {
   if (changedKey === 'a') {
@@ -39,7 +39,7 @@ $test.setKey('b', 5)
 // THROWS Argument of type '"z"' is not assignable to parameter
 $test.setKey('z', '123')
 
-let $testIndexSignature = map<Record<string, number>>()
+let $testIndexSignature = map<Record<string, number>>({})
 $testIndexSignature.setKey('a', 1)
 $testIndexSignature.setKey('a', undefined)
 
@@ -49,3 +49,49 @@ let initialValue: object = $preinitialized.value
 $test.eqKey = (oldValue, newValue, key) => key === 'id' || oldValue === newValue
 // THROWS is not assignable
 $test.eqKey = () => 'not a boolean'
+
+// An empty map still accepts every key of the union, and every branch of
+// the union is still a legal whole value.
+let $partialUnion = map<TestType>()
+$partialUnion.setKey('id', '123')
+$partialUnion.setKey('a', 'string')
+$partialUnion.setKey('b', 5)
+$partialUnion.setKey('isLoading', false)
+// THROWS Argument of type '"z"' is not assignable to parameter
+$partialUnion.setKey('z', 'string')
+
+let $partial = map<{ a: string; b: number }>()
+// Nothing has been set yet, so an empty object is a complete value and
+// every key can be cleared again.
+$partial.set({})
+$partial.set({ a: 'value' })
+$partial.setKey('a', undefined)
+
+let partialValue: Partial<{ a: string; b: number }> = $partial.get()
+// THROWS Type 'string | undefined' is not assignable to type 'string'
+let missingValue: string = $partial.get().a
+
+// Passing `undefined` is the same call as passing nothing, and reads the
+// same way.
+let $explicitUndefined = map<{ a: string }>(undefined)
+// THROWS Type 'string | undefined' is not assignable to type 'string'
+let explicitValue: string = $explicitUndefined.get().a
+
+declare let maybeInitial: undefined | { a: string }
+let $maybeInitial = map(maybeInitial)
+// THROWS Type 'string | undefined' is not assignable to type 'string'
+let maybeValue: string = $maybeInitial.get().a
+
+// A map that definitely got a value keeps every key required.
+let $initialized = map({ a: 'value' })
+let initializedValue: string = $initialized.get().a
+// THROWS Argument of type 'undefined' is not assignable to parameter
+$initialized.set(undefined)
+
+console.log(
+  partialValue,
+  missingValue,
+  explicitValue,
+  maybeValue,
+  initializedValue
+)

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -42,11 +42,11 @@ export type BaseMapStore<Value = any> = {
   setKey: (key: any, value: any) => any
 } & WritableAtom<Value>
 
-export type MapStoreKeys<SomeStore> = SomeStore extends {
-  setKey: (key: infer K, ...args: any[]) => any
-}
-  ? K
-  : AllKeys<StoreValue<SomeStore>>
+export type MapStoreKeys<SomeStore> = SomeStore extends MapStore
+  ? AllKeys<StoreValue<SomeStore>>
+  : SomeStore extends { setKey: (key: infer K, ...args: any[]) => any }
+    ? K
+    : AllKeys<StoreValue<SomeStore>>
 
 export interface MapStore<
   Value extends object = any

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -85,7 +85,7 @@ export interface MapStore<
     listener: (
       value: ReadonlyIfObject<Value>,
       oldValue: ReadonlyIfObject<Value>,
-      changedKey: AllKeys<Value>
+      changedKey: AllKeys<Value> | undefined
     ) => void
   ): () => void
 

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -170,12 +170,22 @@ export interface PreinitializedMapStore<
 }
 
 /**
- * Create map store. Map store is a store with key-value object
- * as a store value.
+ * Create map store with an initial value. Map store is a store with
+ * key-value object as a store value.
  *
- * @param init Initialize store and return store destructor.
+ * @param value Initial store value.
+ * @returns The store object with methods to subscribe.
+ */
+export function map<Value extends object, StoreExt extends object = object>(
+  value: Value
+): PreinitializedMapStore<Value> & StoreExt
+
+/**
+ * Create map store with no initial value, or one that may be missing.
+ *
+ * @param value Initial store value, if there is one.
  * @returns The store object with methods to subscribe.
  */
 export function map<Value extends object, StoreExt extends object = object>(
   value?: Value
-): PreinitializedMapStore<Value> & StoreExt
+): PreinitializedMapStore<Partial<Value>> & StoreExt

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -89,7 +89,7 @@ export interface MapStore<
   listen(
     listener: (
       value: ReadonlyIfObject<Value>,
-      oldValue: ReadonlyIfObject<Value>,
+      oldValue: ReadonlyIfObject<Value> | undefined,
       changedKey: AllKeys<Value> | undefined
     ) => void
   ): () => void

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -52,7 +52,7 @@ export interface MapStore<
   Value extends object = any
 > extends WritableAtom<Value> {
   /**
-   * Compares the previous and next values for a key on every `setKey`.
+   * Compares the previous and next values for a key on `setKey`.
    *
    * Returning `true` means the values are the same, so the store keeps the old
    * value and no listener is called.
@@ -62,8 +62,8 @@ export interface MapStore<
    * yet.
    *
    * @remarks
-   * Deleting a key with `setKey(key, undefined)` does not call it. Whole-value
-   * writes use {@link ReadableAtom#eq} instead.
+   * Deleting an existing key skips the comparison and notifies either way.
+   * Whole-value writes use {@link ReadableAtom#eq} instead.
    *
    * @default Object.is
    * @returns `true` if the values are equal, `false` otherwise.
@@ -81,9 +81,7 @@ export interface MapStore<
    * immediately.
    *
    * @param listener Callback with store value and old value.
-   * @param changedKey Key that was changed. Will present only if `setKey`
-   *                   has been used to change a store. It is `undefined` when
-   *                   changes were coalesced inside `batch`.
+   * @param changedKey Key that changed, when the notification carries one.
    * @returns Function to remove listener.
    */
   listen(
@@ -149,9 +147,7 @@ export interface MapStore<
    * ```
    *
    * @param listener Callback with store value and old value.
-   * @param changedKey Key that was changed. Will present only
-   *                   if `setKey` has been used to change a store. It is
-   *                   `undefined` when changes were coalesced inside `batch`.
+   * @param changedKey Key that changed, when the notification carries one.
    * @returns Function to remove listener.
    */
   subscribe(

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -69,8 +69,8 @@ export interface MapStore<
    * @returns `true` if the values are equal, `false` otherwise.
    */
   eqKey<Key extends AllKeys<Value>>(
-    oldValue: Get<Value, Key>,
-    newValue: Get<Value, Key>,
+    oldValue: Get<Value, Key> | undefined,
+    newValue: Get<Value, Key> | undefined,
     key: Key
   ): boolean
 

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -22,14 +22,19 @@ export type WritableStore<Value = any> =
 
 export type Store<Value = any> = ReadableAtom<Value> | WritableStore<Value>
 
-export type AnyStore<Value = any> = {
+export type Gettable<Value = any> = {
   get(): Value
+}
+
+export type AnyStore<Value = any> = Gettable<Value> & {
   readonly value: undefined | Value
 }
 
-export type StoreValue<SomeStore> = SomeStore extends {
-  get(): infer Value
+export type ListenableStore<Value = any> = Gettable<Value> & {
+  listen(listener: () => void): () => void
 }
+
+export type StoreValue<SomeStore> = SomeStore extends Gettable<infer Value>
   ? Value
   : any
 

--- a/map/index.test.ts
+++ b/map/index.test.ts
@@ -121,8 +121,8 @@ test('supports complicated case of last unsubscribing', () => {
 test('supports the same listeners', () => {
   let events: string[] = []
   function listener(
-    value: { a: number },
-    oldValue: { a: number },
+    value: Partial<{ a: number }>,
+    oldValue: Partial<{ a: number }>,
     key: 'a' | undefined
   ): void {
     if (key !== undefined) events.push(`${key}: ${value[key]}`)

--- a/map/index.test.ts
+++ b/map/index.test.ts
@@ -122,7 +122,7 @@ test('supports the same listeners', () => {
   let events: string[] = []
   function listener(
     value: Partial<{ a: number }>,
-    oldValue: Partial<{ a: number }>,
+    oldValue: Partial<{ a: number }> | undefined,
     key: 'a' | undefined
   ): void {
     if (key !== undefined) events.push(`${key}: ${value[key]}`)

--- a/map/index.test.ts
+++ b/map/index.test.ts
@@ -123,9 +123,9 @@ test('supports the same listeners', () => {
   function listener(
     value: { a: number },
     oldValue: { a: number },
-    key: 'a'
+    key: 'a' | undefined
   ): void {
-    events.push(`${key}: ${value[key]}`)
+    if (key !== undefined) events.push(`${key}: ${value[key]}`)
   }
 
   let $store = map<{ a: number }>()
@@ -259,7 +259,7 @@ test('changes the whole object', () => {
     $store.setKey('b', 0)
   })
 
-  let changes: string[] = []
+  let changes: (string | undefined)[] = []
   $store.listen((value, oldValue, key) => {
     changes.push(key)
   })
@@ -276,7 +276,7 @@ test('changes the whole object', () => {
 test('does not call listeners on no changes', () => {
   let $store = map({ one: 1 })
 
-  let changes: string[] = []
+  let changes: (string | undefined)[] = []
   $store.listen((value, oldValue, key) => {
     changes.push(key)
   })

--- a/map/index.test.ts
+++ b/map/index.test.ts
@@ -293,7 +293,7 @@ test('uses custom eqKey to skip equal key writes', () => {
   let $store = map({ name: 'Ada' })
   $store.eqKey = (oldValue, newValue, key) => {
     comparedKeys.push(key)
-    return oldValue.toLowerCase() === newValue.toLowerCase()
+    return oldValue?.toLowerCase() === newValue?.toLowerCase()
   }
 
   $store.listen((_value, _oldValue, key) => {
@@ -343,7 +343,7 @@ test('uses eq for whole value writes and eqKey only for key writes', () => {
   let initial = { count: 1 }
 
   let $store = map<{ count: number }>(initial)
-  $store.eq = (oldValue, newValue) => oldValue.count === newValue.count
+  $store.eq = (oldValue, newValue) => oldValue?.count === newValue.count
   $store.eqKey = () => {
     eqKeyCalls += 1
     return false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,12 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "esModuleInterop": true,
     "isolatedModules": true,
     "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     "noEmit": true,
     "noImplicitOverride": true,
     "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
-    "stableTypeOrdering": true,
     "strict": true,
     "target": "es2024",
     "types": ["node"]


### PR DESCRIPTION
I went through the type declarations and fixed the ones that are wrong. Some were wrong from the start, others drifted as the JavaScript changed. In every case the runtime does the right thing and the type describes something else.

Only one commit touches runtime code — a small guard in `listenKeys`. 

Bundle size doesn't move; no commit touches `package.json`.

Each commit is a single fix, with the full reasoning in its message: what was wrong, how I confirmed it, and what I deliberately left alone. The commits are the real description. They're logically independent of each other, but several touch the same declaration files in sequence — so dropping commits off the end is clean, while picking one out of the middle will need conflict resolution. `pnpm test` passes at every one of the seventeen commits, not just the final state.

## The commits, grouped by impact

Oldest first inside each group. Several of these are correct but stricter, so TypeScript will start complaining about code that used to compile. Nearly all of that code was already unsafe at runtime, and the examples in the docs were written the guarded way. The first group is safe for any release; the second can surface new compile errors; the last two are the ones I'd hold for a major.

### Safe or additive — I don't expect anyone to change anything

- `701bf01` **Remove redundant TSConfig options** — dropped options TypeScript 7 already turns on.
- `3db19fc` **Accept readonly source tuples in computed, batched, and effect** — you can now pass a source list declared with `as const`.
- `f6b3301` **Export StoreValues from package root** — the type was unreachable, because `nanostores/computed` doesn't resolve for consumers.
- `4b5c27d` **Remove stale notifyId declaration** — the runtime dropped that export in 2023 and the declaration kept insisting it was there.
- `5a81ffc` **Handle a missing old value in listenKeys** — it no longer throws when a notification arrives without an old value. This is the one runtime change, and the one commit that touches files nothing else does.
- `115a546` **Correct TSDoc that contradicts the runtime** — comments only. Two statements in map and deep-map described behaviour the runtime doesn't have; both predate this branch.

### Might surface errors, but only where the code was already unsound

- `efd62e3` **Fix listenKeys callback types** — the changed key is a single key or nothing, never an array.
- `bb6d509` **Fix map listener changed key type** — the changed key can be missing.
- `24bd94e` **Split the source contract for computed, batched, and effect** — `effect()` accepts anything it can read and listen to; `computed()` and `batched()` need a real Nano Store.
- `33d442c` **Require onMount initializer** — it's mandatory again, which is what the runtime has always assumed.
- `ec54479` **Allow a missing old value in onNotify payloads** — lifecycle handlers can be called without one.
- `9f0c427` **Fix mapCreator return types** — created stores carry `id`, and store extensions have to be declared.
- `de8c2ff` **Fix lifecycle payload changed key type** — for a union value, the changed key can come from any branch.
- `de8c2ff` **Fix lifecycle payload changed keys for deep maps** — deep maps report full paths, not top-level keys.
- `e357203` **Fix map keys hijacked by store extensions** — an extension that declares its own `setKey` no longer replaces the map's real keys. Narrow case; if you've never done that, nothing changes.
- `0ab15cc` **Allow missing values in eq and eqKey** — the comparison callbacks can be called without a previous value.

### The two that reach ordinary, correct-looking code

- `a5b70a2` **Fix map types without initial value** — `map<Value>()` with no argument now gives you `Partial<Value>`, because the store really does start empty. This touches every property read on such a store.
- `b38a2d7` **Allow a missing old value in listen callbacks** — the old value can be missing. This touches every listener that reads its second argument, so it's the widest change here.

---

Merge as is, split across 1.5 and 2.0, or drop what you'd rather not ship — glad to reshape it either way. So it's your call.

#### What I left out

I found more while I was in there, but it's either in deprecated parts (async `computed`, deep maps) or not a type problem at all. I'll open those separately.