### PR TITLE
Fix map key value types collapsing to never

### DIFF
--- a/map/errors.ts
+++ b/map/errors.ts
@@ -45,6 +45,14 @@ $test.setKey('b', 5)
 // THROWS Argument of type '"z"' is not assignable to parameter
 $test.setKey('z', '123')
 
+// A key carried by only one union member still has its value checked.
+// THROWS Argument of type 'number' is not assignable to parameter of type 'string'
+$test.setKey('a', 5)
+// THROWS Argument of type 'undefined' is not assignable to parameter of type 'string'
+$test.setKey('a', undefined)
+// THROWS Argument of type 'number' is not assignable to parameter of type 'string'
+$test.setKey('id', 5)
+
 let $testIndexSignature = map<Record<string, number>>({})
 $testIndexSignature.setKey('a', 1)
 $testIndexSignature.setKey('a', undefined)
@@ -65,6 +73,18 @@ $counted.eqKey = (oldValue, newValue, key) => {
   return key === 'a' && oldValue === newValue
 }
 
+let $lazyCounted = map<{ a: number }>()
+// A map with no initial value still compares real values, not only `undefined`.
+let lazyEqual: boolean = $lazyCounted.eqKey(1, 2, 'a')
+let lazyMissing: boolean = $lazyCounted.eqKey(undefined, 2, 'a')
+// THROWS Argument of type 'string' is not assignable to parameter
+$lazyCounted.eqKey('nope', 2, 'a')
+
+// An index signature supplies the value type the same way a declared key does.
+let indexEqual: boolean = $testIndexSignature.eqKey(1, 2, 'a')
+// THROWS Argument of type 'string' is not assignable to parameter
+$testIndexSignature.eqKey('nope', 2, 'a')
+
 // An empty map still accepts every key of the union, and every branch of
 // the union is still a legal whole value.
 let $partialUnion = map<TestType>()
@@ -74,6 +94,9 @@ $partialUnion.setKey('b', 5)
 $partialUnion.setKey('isLoading', false)
 // THROWS Argument of type '"z"' is not assignable to parameter
 $partialUnion.setKey('z', 'string')
+let unionEqual: boolean = $partialUnion.eqKey('old', 'new', 'a')
+// THROWS Argument of type 'number' is not assignable to parameter
+$partialUnion.eqKey(5, 'new', 'a')
 
 let $partial = map<{ a: string; b: number }>()
 // Nothing has been set yet, so an empty object is a complete value and
@@ -112,6 +135,10 @@ let extendedKey: MapStoreKeys<typeof $extended> = 'a'
 extendedKey = 'ext'
 
 console.log(
+  lazyEqual,
+  lazyMissing,
+  indexEqual,
+  unionEqual,
   partialValue,
   missingValue,
   explicitValue,

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -7,14 +7,22 @@ import type {
 
 type KeyofBase = keyof any
 
-type Get<T, K extends KeyofBase> = Extract<T, { [K1 in K]: any }>[K]
+type Get<T, K extends KeyofBase> = T extends any
+  ? K extends keyof T
+    ? T[K]
+    : never
+  : never
 
 export type HasIndexSignature<T> = string extends keyof T ? true : false
 
 export type ValueWithUndefinedForIndexSignatures<
   Value,
-  Key extends keyof Value
-> = HasIndexSignature<Value> extends true ? undefined | Value[Key] : Value[Key]
+  Key extends KeyofBase
+> = Value extends any
+  ? HasIndexSignature<Value> extends true
+    ? undefined | Get<Value, Key>
+    : Get<Value, Key>
+  : never
 
 export type WritableStore<Value = any> =
   | (Value extends object ? MapStore<Value> : never)
@@ -132,7 +140,7 @@ export interface MapStore<
    */
   setKey<Key extends AllKeys<Value>>(
     key: Key,
-    value: Get<Value, Key> | ValueWithUndefinedForIndexSignatures<Value, Key>
+    value: ValueWithUndefinedForIndexSignatures<Value, Key>
   ): void
 
   /**


### PR DESCRIPTION
> This should have been part of the previous types fixes, but I discovered it much later and had to verify its correctness.

### Changes

- Replaced `Get`'s `Extract` filter with a distributive conditional that indexes each union member where the key exists.
- Relaxed `ValueWithUndefinedForIndexSignatures` from `Key extends keyof Value` to `Key extends KeyofBase`.
- Switched alias in that type from `Value[Key]` to `Get<Value, Key>` and distributed it over `Value`, so a union is indexed per member and `HasIndexSignature` is tested per member.
- Dropped the now-redundant `Get<Value, Key> |` arm from `setKey`'s value parameter.
- Declarations only — no runtime change, `size-limit` unchanged.

### Compatibility

- `eqKey` only widens: its parameters go from `undefined` to the real value type, so every existing implementation still compiles.
- `setKey` tightens for union values. A wrong value passed with a key that only part of the union declares used to compile through the error type and now errors. Those writes were never checked, so this can surface new errors in code that type checked before.

### Tests

11 fixtures in `map/errors.ts`, each verified to fail against the previous declarations: union value checks on `setKey`, and `eqKey` on partial, index-signature, and union values.

---

## Simple explanation:
1. Map's `setKey` second argument had type `value: Get<Value, Key> | ValueWithUndefinedForIndexSignatures<Value, Key>`. `Get` was broken and collapsed to never sometimes, and never disappears in a union, so `ValueWithUndefinedForIndexSignatures` silently covered for it on plain objects. On union types it was the reverse: `ValueWithUndefinedForIndexSignatures` collapsed to `any` (see 3A) and swallowed `Get`'s correct answer. Once `ValueWithUndefinedForIndexSignatures` is fixed it uses `Get` internally anyway, so the first part is redundant and I dropped it.
2. `Get` itself was broken. While the old shape
    ```ts
    type Get<T, K> = Extract<T, { [K1 in K]: any }>[K]
    ```
    worked for most common cases, it required the key to be definitely present. So in cases like this:
    ```ts
    { a?: number }
    { [k: string]: number }
    ```
    it would fail and return `never`.

3. `ValueWithUndefinedForIndexSignatures` had its own problems. Two, actually. It was declared as:
    ```ts
    export type ValueWithUndefinedForIndexSignatures<
      Value,
      Key extends keyof Value  // problem A
    > = HasIndexSignature<Value> extends true
      ? undefined | Value[Key] // problem B
      : Value[Key]
    ```
  - **A:** `Key extends keyof Value` was requesting keys of `Value`,  which, in case of union types, would require keys present in all members. But `setKey` supplies `AllKeys<Value>` (`setKey<Key extends AllKeys<Value>>`), which is any valid key from any member of the union. Passing such a key violated the constraint, and TS resolved the whole reference to an error type `any` without reporting it anywhere. This is why we had to relax it.
  - **B:** Same union problem, `Value[Key]` can't index a union by a key that isn't on every branch. So we switched here to the fixed `Get<Value, Key>` that is used for that purpose.
  - One more small note: `Value extends any` was added at the very top of the type, so `HasIndexSignature` is tested per union member instead of once on the whole union (same trick (generic + condition) for unions that we also used in previous pull: `T extends any ? keyof T : never`).